### PR TITLE
chore: bump plugin patch version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "basis-based gap analysis, repo rule reflection, and operational handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "author": {
     "name": "MTGVim"
   },


### PR DESCRIPTION
No eligible open issue was available for autopilot processing. This standalone patch-bump fallback is required because `origin/main` latest commit is not a plugin version bump commit.

Summary:
- Bumped `.claude-plugin/plugin.json` from `6.3.2` to `6.3.3`.

Version:
- Bumped plugin patch version from 6.3.2 to 6.3.3 because origin/main latest commit is not a version bump commit.

Validation:
- [x] `claude plugin validate .claude-plugin/plugin.json`
- [x] `claude plugin validate .`
- [x] `python3 -m json.tool evals/evals.json >/dev/null`
- [x] `git diff --check`

Notes:
- `claude plugin validate .` passed with existing warning: `CLAUDE.md at the plugin root is not loaded as project context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)