### PR TITLE
chore: bump plugin patch version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "basis-based gap analysis, repo rule reflection, and operational handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "6.3.3",
+  "version": "6.3.4",
   "author": {
     "name": "MTGVim"
   },


### PR DESCRIPTION
No eligible open issue was available, so this PR uses the standalone marketplace plugin patch-bump fallback.

Summary:
- Bumped `.claude-plugin/plugin.json` patch version from 6.3.3 to 6.3.4.
- Open issue scan returned no open issues.
- origin/main latest commit is not a direct plugin version bump commit, so fallback bump is required by autopilot policy.

Version:
- Bumped plugin patch version from 6.3.3 to 6.3.4 because origin/main latest commit is not a version bump commit.

Validation:
- `claude plugin validate .claude-plugin/plugin.json` passed with existing CLAUDE.md packaging warning.
- `claude plugin validate .` passed.
- `python3 -m json.tool evals/evals.json >/dev/null` passed.
- `git diff --check` passed.

Notes:
- No issue linked because this is fallback maintenance work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)