### PR TITLE
chore: bump plugin patch version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "basis-based gap analysis, repo rule reflection, and operational handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "6.3.4",
+  "version": "6.3.5",
   "author": {
     "name": "MTGVim"
   },


### PR DESCRIPTION
## Summary
- No eligible open GitHub issues were available.
- Bumped `.claude-plugin/plugin.json` patch version from 6.3.4 to 6.3.5.
- This fallback is required because `origin/main` latest commit is not a plugin patch/version bump commit.

## Validation
- `claude plugin validate .claude-plugin/plugin.json` passed with existing CLAUDE.md warning.
- `claude plugin validate .` passed.
- `python3 -m json.tool evals/evals.json >/dev/null` passed.
- `git diff --check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)