### PR TITLE
feat: add gap target freshness preflight

### DIFF
--- a/.claude/rules/review/gap-analysis.md
+++ b/.claude/rules/review/gap-analysis.md
@@ -62,7 +62,7 @@ Required handling:
 - In `mode=analysis`, keep questions inside the single Findings table.
 - In `mode=review`, write ambiguity as an `Ask:` with the question category, recommendation, and evidence, not as a confirmed defect.
 
-## GAP-007: Check current implementation freshness before comparing
+## Target freshness: Check current implementation freshness before comparing
 
 When the target means `current implementation`, current working tree, current branch, or local checkout:
 

--- a/.claude/rules/review/gap-analysis.md
+++ b/.claude/rules/review/gap-analysis.md
@@ -61,3 +61,14 @@ Required handling:
 - Split questions into `implementation-blocking` and `reference-only`.
 - In `mode=analysis`, keep questions inside the single Findings table.
 - In `mode=review`, write ambiguity as an `Ask:` with the question category, recommendation, and evidence, not as a confirmed defect.
+
+## GAP-007: Check current implementation freshness before comparing
+
+When the target means `current implementation`, current working tree, current branch, or local checkout:
+
+- Identify the integration branch tip first. Prefer the repository default remote branch; use `origin/main` when that is the repository convention.
+- Refresh or verify remote metadata when possible. If freshness cannot be verified, report base freshness as `cannot_verify` evidence.
+- If local `HEAD` is behind the integration branch, check whether files in the requested scope or target evidence changed between `HEAD` and the integration tip.
+- If behind changes affect the target area, compare against the integration branch tip shape instead of stale local `HEAD`, and report the base state in the Summary Table or first finding.
+- If behind changes do not affect the target area, the local target may still be used, but report the freshness check briefly.
+- If the user explicitly names a commit, branch, PR diff, or working tree state as the target, do not switch targets silently; report stale status as evidence instead.

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -44,6 +44,7 @@ Plugin namespace는 `/tk:*`입니다. 해당 workflow를 명시한 자연어 요
 ### `/tk:gap`
 
 - 입력된 basis와 target을 직접 확인 가능한 근거로 비교합니다. basis는 Spec reference를 포함할 수 있는 비교 자료이지 절대적 진실이 아닙니다.
+- target이 `current implementation` 또는 현재 checkout을 뜻하면 integration branch 대비 stale 여부를 먼저 확인합니다. 현재 `HEAD`가 behind이고 대상 영역 파일이 영향권이면 integration branch tip 형상으로 비교하고, Summary Table 또는 첫 finding에 base 상태를 명시합니다.
 - `mode=analysis`는 compact `## Summary Table`, `## Findings`, `## Bottom Recap`만 출력합니다. Summary Table은 결과 count와 핵심 next action을 table로 보여주고, Bottom Recap은 긴 Findings 뒤에 핵심 결론을 반복합니다.
 - `mode=review`는 PR-ready basis-target gap comment만 출력합니다. 일반 code review가 아닙니다.
 - `mode=both`는 analysis 뒤에 basis-target gap comment를 출력하며 같은 finding에 같은 Short ID와 stable ID를 사용합니다.

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -39,6 +39,18 @@ basis끼리 충돌하면 Status를 `conflicting_sources`로 둡니다.
 증거가 부족해 판정할 수 없으면 Status를 `cannot_verify`로 둡니다.
 접근할 수 없는 외부 URL, 이미지, Figma/design link, screenshot URL, local path는 Status를 `blocked_external`로 둡니다.
 
+## Target Freshness Preflight
+
+`target`이 `current implementation`, 현재 작업 트리, 현재 branch, local checkout을 뜻하면 gap 분석 전에 target freshness를 확인합니다.
+
+규칙:
+- Git repository이면 integration branch tip을 식별합니다. 기본 후보는 `origin/main`이며, repository default branch가 다르면 그 remote tracking branch를 사용합니다.
+- 가능하면 remote metadata를 먼저 갱신하거나 현재 `origin/<default-branch>`가 최신인지 확인합니다. 확인할 수 없으면 base freshness를 `cannot_verify` 근거로 보고합니다.
+- 현재 `HEAD`가 integration branch tip보다 behind이면, 요청 scope 또는 target evidence로 읽을 파일들이 `HEAD..integration` 사이에서 바뀌었는지 확인합니다.
+- behind이고 대상 영역 파일이 영향권이면 stale checkout을 target으로 삼아 `needs_fix`를 재보고하지 않습니다. 비교 target을 integration branch tip 형상으로 전환하고, Summary Table의 `Target` 또는 `Key Next Action`에 base 상태와 전환 사실을 명시합니다.
+- behind이지만 대상 영역 파일이 영향권이 아니면 기존 target으로 비교할 수 있습니다. 이때도 Summary Table 또는 첫 finding에 checkout freshness 상태를 짧게 남깁니다.
+- 사용자가 특정 commit, branch, PR diff, working tree 상태를 명시적으로 target으로 고정하면 임의로 전환하지 않습니다. 대신 stale 여부를 evidence로 보고합니다.
+
 ## Ambiguity Handling
 
 아래 조건 중 하나라도 있으면 조용히 결정하지 않습니다.
@@ -245,11 +257,12 @@ rule ID가 있으면 Basis 또는 Finding에 함께 적습니다.
 ## 절차
 
 1. basis와 target을 식별합니다.
-2. 요청에서 mode output profile을 결정합니다.
-3. 관련 basis와 target evidence를 읽습니다.
-4. UI copy exactness, 요구사항 충족, 규칙 준수, 접근성, 테스트 공백을 확인합니다.
-5. 각 finding에 Short ID, stable ID, Scope, Type, Severity, Status를 부여합니다.
-6. `mode=analysis`, `mode=review`, `mode=both` 중 하나의 형식으로 답합니다.
+2. target이 current implementation 계열이면 Target Freshness Preflight를 실행합니다.
+3. 요청에서 mode output profile을 결정합니다.
+4. 관련 basis와 target evidence를 읽습니다.
+5. UI copy exactness, 요구사항 충족, 규칙 준수, 접근성, 테스트 공백을 확인합니다.
+6. 각 finding에 Short ID, stable ID, Scope, Type, Severity, Status를 부여합니다.
+7. `mode=analysis`, `mode=review`, `mode=both` 중 하나의 형식으로 답합니다.
 
 ## 금지
 


### PR DESCRIPTION
## Summary
- Adds `/tk:gap` target freshness preflight for `current implementation` / current checkout targets.
- Adds generalized repo guidance so stale checkout comparisons do not re-report already-fixed gaps as `needs_fix`.
- Updates TigerKit usage docs to document stale-target handling.
- Notes: issue also mentioned stop-advisor false positives; current `origin/main` already removes the handoff/reflect advisor, and this PR leaves the verification manifest guard intact.

Fixes #48

## Validation
- `claude plugin validate .claude-plugin/plugin.json` passed with existing CLAUDE.md warning.
- `claude plugin validate .` passed.
- `python3 -m json.tool evals/evals.json >/dev/null` passed.
- `git diff --check` passed.
- Verified freshness guidance appears in `commands/gap.md`, `.claude/rules/review/gap-analysis.md`, and `.tigerkit/docs/usage.md`.
- Verified removed handoff/reflect advisor strings are absent from stop hook and usage docs.
- Verified `GAP-007` no longer appears in the changed guidance after PR feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)