### PR TITLE
docs: simplify gap output surface

### DIFF
--- a/.claude/rules/review/gap-analysis.md
+++ b/.claude/rules/review/gap-analysis.md
@@ -41,15 +41,15 @@
 
 ## GAP-005: Match output to v7 storage and stdout contract
 
-- Default stdout emits summary receipt plus compact tables: run ID, branch scope, quality gates, analysis depth, expansion reasons, verification escalation, status, report path, performance proof, heuristic proof, P0/P1/P2 counts, compact Actionable Findings table, compact Rejected/Downgraded table, source conflict count, clarification-needed count, and rejected/downgraded count.
-- Use `품질 gate: evidence precision + producer evidence + ambiguity + JudgeMerger` and `분석 깊이` by default. Do not use preset labels as primary output.
+- Default stdout emits a compact user receipt only: run ID, branch scope, P0/P1/P2 counts, source conflict count, clarification-needed count, report path, and next action.
+- Do not print quality gate, analysis depth, expansion reasons, verification escalation, performance proof, heuristic proof, baseline refresh, proof freshness, or artifact file lists in default stdout. Store them in `report.md` or JSON artifacts.
 - Do not use ambiguous labels like `선택모드`, `실행모드`, `실행 preset`, and `추천 preset`.
 - State that the run is complete for the 단일 `/tk:gap` 실행; do not imply the gap is unfinished.
 - Full report is stored at `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md`.
-- Compact stdout tables may include accepted finding and rejected/downgraded observation summaries, but they must use run-local `Ref` values rather than long canonical Candidate/Finding IDs.
-- Detailed evidence, source contract detail, and canonical ID mapping remain in `report.md` or JSON artifacts unless `--print-report` is used.
+- Default stdout may include compact Actionable Findings and Clarification Needed tables only when those rows exist. Tables must use run-local `Ref` values rather than long canonical Candidate/Finding IDs.
+- Detailed evidence, source contract detail, rejected/downgraded observations, proof metadata, artifact inventory, and canonical ID mapping remain in `report.md` or JSON artifacts unless `--print-report` is used.
 - Full report stdout is allowed only with `--print-report`.
-- Run artifacts must include `input-manifest.json`, `contracts.json`, `candidates.json`, `judge-result.json`, and `report.md`.
+- Run artifacts must include `input-manifest.json`, `contracts.json`, `candidates.json`, `judge-result.json`, `baseline-snapshot.json`, and `report.md`; these files are audit/machine surfaces, not the default user output surface.
 - `input-manifest.json` or `judge-result.json` must record `qualityGates`, `analysisDepth`, `depthReasons`, `riskScore`, `sideEffectConfidence`, `verificationEscalation`, `compatibilityFlags`, `dispatchPlan`, `dispatchSkips`, `candidateIntakeGate`, `evidencePrecisionGate`, `targetSurfaceCoverageGate`, `dispatchCompletenessGate`, `blockedClarifications`, `performance`, and `heuristicProof`.
 - Do not store generated gap artifacts in `/tmp`, `$GIT_COMMON_DIR`, `.git/worktrees/*`, user home, or current worktree root outside `.claude/tigerkit/branches/<branch-key>/`.
 
@@ -168,7 +168,7 @@ When the target means `current implementation`, current working tree, current br
 
 ## GAP-016: Require combined heuristic proof for improvement claims
 
-- A `/tk:gap` run receipt, report, or contract output may claim the current 1.3x improvement target only when `heuristicProof.requiredImprovementRatio` is `1.3` and false-positive, false-negative, speed, and analysis-depth subproofs all meet or exceed it with `claimAllowed: true`.
+- A `/tk:gap` report or contract output may claim the current 1.3x improvement target only when `heuristicProof.requiredImprovementRatio` is `1.3` and false-positive, false-negative, speed, and analysis-depth subproofs all meet or exceed it with `claimAllowed: true`. Default stdout does not print this proof claim.
 - `heuristicProof.falsePositive` must prove accepted-path gate coverage, including CandidateShapeGate, EvidencePrecisionGate, ProducerEvidenceGate, ConflictClarificationGate, RequirementTraceabilityGate, SeverityScopeGate, and JudgeMergerAgent.
 - `heuristicProof.falseNegative` must prove missed-critical coverage, including SourcePresenceManifest, ActiveSpecPatchCoverage, TargetHintExtraction, TargetSurfaceCoverageGate, DispatchCompletenessGate, and CriticalRedTeamAgent missed-P0/P1 search.
 - `heuristicProof.speed` must mirror recorded `performance` fields and may not count uncredited dispatch skips.

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -72,6 +72,8 @@ baseline-snapshot.json
 report.md
 ```
 
+이 6개 파일은 모두 필요합니다. 다만 사용자 기본 output surface는 파일 목록 전체가 아니라 `report.md` 경로입니다. JSON 파일과 `baseline-snapshot.json`은 reproducible audit, machine-readable proof, canonical ID mapping, baseline refresh를 위한 내부/검증 표면입니다.
+
 단일 `/tk:gap` 실행은 metadata와 execution order를 바꾸며, artifact location은 유지하고 기존 required file name에 `baseline-snapshot.json`을 추가합니다. `heuristicProof`, `heuristicProof.baselineProvenance`, `heuristicProof.baselineAutoRefreshGate`, `baselineAutoRefreshGate`, `performance`, `dispatchPlan`, `dispatchSkips`, `candidateIntakeGate`, `targetSurfaceCoverageGate`, `dispatchCompletenessGate`, `claimFreshnessGate`는 `input-manifest.json` 또는 `judge-result.json`에 기록합니다. `baseline-snapshot.json`은 same-run baseline score snapshot과 next iteration promotion candidate를 보관합니다.
 
 ## Branch key

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -64,42 +64,38 @@ Items:
 기본 stdout:
 
 ```text
-Gap Review 시작: <GAP-ID>
+Gap Review 완료: <GAP-ID>
 Branch Scope: <branch-key>
-품질 gate: evidence precision + producer evidence + ambiguity + JudgeMerger
-분석 깊이: <direct|bounded|expanded|exhaustive-capped>
-확장 이유: <none|summary>
-검증 강화: <none|targeted-red-team>
-상태: 완료
+결과: P0 <count> / P1 <count> / P2 <count> / Source Conflicts <count> / Clarification Needed <count>
 Report: .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md
-성능 증명: cumulative <ratio>x / iteration <ratio>x by <measurementMethod>
-누적 개선 증명: FP <ratio>x / FN <ratio>x / speed <ratio>x / depth <ratio>x
-반복 개선 증명: FP <ratio>x / FN <ratio>x / speed <ratio>x / depth <ratio>x
-Baseline: cumulative <sourceRef> / iteration <sourceRef>
-Baseline refresh: <pass|blocked> from <registryPath>
-Proof freshness: <pass|blocked>
-
-Findings:
-- P0: <count>
-- P1: <count>
-- P2: <count>
+다음 행동: <G1 먼저 수정|Q1 확인 필요|없음>
 
 Actionable Findings:
-| Ref | Sev | 요약 | 의미 | Required change |
-| --- | --- | --- | --- | --- |
-| G1 | P1 | <final finding 1줄 요약> | <사용자/제품 관점 영향 1줄> | <수정 방향 1줄> |
-
-Rejected/Downgraded:
-| Ref | Reason | 요약 | 왜 final gap 아님 |
+| Ref | Sev | 요약 | Required change |
 | --- | --- | --- | --- |
-| R1 | missing_evidence | <observation 1줄 요약> | <reject/downgrade 이유 1줄> |
+| G1 | P1 | <final finding 1줄 요약> | <수정 방향 1줄> |
 
-Source Conflicts: <count>
-Clarification Needed: <count>
-Rejected/Downgraded: <count>
+Clarification Needed:
+| Ref | 질문 | 추천 |
+| --- | --- | --- |
+| Q1 | <확인 질문 1줄> | <추천 1줄> |
 ```
 
-Run artifact files:
+`Actionable Findings`는 accepted finding이 있을 때만 출력합니다. `Clarification Needed`는 확인 질문이 있을 때만 출력합니다. 둘 다 없으면 table 대신 `다음 행동: 없음`만 출력합니다.
+
+Default stdout에 아래 항목을 직접 출력하지 않습니다. 사용자가 확인해야 하는 세부 근거는 `report.md`, 기계 판정과 proof는 JSON artifact에 저장합니다.
+
+- quality gate
+- analysis depth와 확장 이유
+- verification escalation
+- performance proof
+- heuristic proof
+- baseline refresh
+- proof freshness
+- rejected/downgraded observation 목록
+- artifact file list
+
+Run artifact files are required audit/machine surfaces, not the default user output surface:
 
 ```text
 input-manifest.json

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -88,8 +88,8 @@ Plugin namespace는 `/tk:*`입니다. 해당 workflow를 명시한 자연어 요
 - P3/nit/duplicate/unverifiable/source_conflict는 final finding이 아닙니다.
 - finding이 0개가 될 때까지 반복하지 않습니다.
 - run artifact는 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/` 아래에 저장합니다.
-- 기본 stdout은 summary만 출력합니다. 전체 report는 `--print-report`가 있을 때만 출력합니다.
-- stdout과 report에는 단일 `/tk:gap` 실행 완료 상태, analysis depth, 확장 이유, 성능 증명, compact tables를 남깁니다.
+- 기본 stdout은 run 결과, finding/clarification count, report path, next action만 출력합니다. 전체 report는 `--print-report`가 있을 때만 출력합니다.
+- analysis depth, 확장 이유, 성능 증명, heuristic proof, baseline 상태, rejected/downgraded observation, artifact file list는 기본 stdout이 아니라 `report.md`와 JSON artifact에 저장합니다.
 - 유저향 compact table은 긴 Candidate/Finding ID 대신 run-local short Ref(`G1`, `R1`, `C1`, `Q1`)를 우선 표시하고, canonical ID는 JSON artifact와 report 상세/참조 영역에 보관합니다.
 - hook은 사용자-facing receipt, artifact path, finding Ref 안전장치일 때만 추가합니다. repo 유지보수용 sync/lint 성격이면 hook을 두지 않습니다.
 

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -44,10 +44,10 @@ gap = branch-local contract-based inspection + judge-driven final finding
 - visible UI copy는 confirmed contract와 exact match가 필요합니다.
 - finding이 안 나올 때까지 반복하지 않습니다.
 - CriticalRedTeamAgent pass는 targeted verification으로 최대 1회입니다.
-- stdout은 summary receipt와 compact finding tables만 출력하고 상세는 report.md에 저장합니다.
+- stdout은 run 결과, finding/clarification count, report path, next action만 기본 출력하고 상세는 report.md와 JSON artifact에 저장합니다.
 - 유저향 stdout/report table은 run-local short Ref(`G1`, `R1`, `C1`, `Q1`)를 우선 표시하고 긴 canonical ID는 JSON artifact와 report 상세/참조 영역에 보관합니다.
 - Hook guard는 repo 유지보수 sync/lint가 아니라 플러그인 사용자가 보는 receipt, artifact path, finding Ref 안전장치일 때만 사용합니다. 그런 user-facing guard 표면이 없으면 hook을 추가하지 않습니다.
-- run summary와 report에는 analysis depth, 확장 이유, 성능 증명을 남깁니다.
+- `report.md`와 JSON artifact에는 analysis depth, 확장 이유, 성능 증명을 남깁니다.
 
 ## Terminology
 
@@ -96,7 +96,9 @@ baseline-snapshot.json
 report.md
 ```
 
-`input-manifest.json` 또는 `judge-result.json`에는 `qualityGates`, `analysisDepth`, `depthReasons`, `riskScore`, `sideEffectConfidence`, `verificationEscalation`, `compatibilityFlags`, `dispatchPlan`, `dispatchSkips`, `candidateIntakeGate`, `evidencePrecisionGate`, `targetSurfaceCoverageGate`, `dispatchCompletenessGate`, `blockedClarifications`, `baselineAutoRefreshGate`, `claimFreshnessGate`, `performance`, `heuristicProof`를 반드시 기록합니다. `baseline-snapshot.json`에는 같은 run에서 사용한 cumulative/iteration/current score snapshot과 다음 반복 승격 후보를 저장합니다. 둘 다에 중복 기록할 필요는 없지만, `report.md`와 stdout은 같은 canonical metadata를 참조해야 합니다.
+이 6개 파일은 모두 gap run의 audit/machine surface입니다. 기본 stdout에 파일 목록을 노출하지 말고, 사용자가 열 기본 표면은 `report.md`로 안내합니다.
+
+`input-manifest.json` 또는 `judge-result.json`에는 `qualityGates`, `analysisDepth`, `depthReasons`, `riskScore`, `sideEffectConfidence`, `verificationEscalation`, `compatibilityFlags`, `dispatchPlan`, `dispatchSkips`, `candidateIntakeGate`, `evidencePrecisionGate`, `targetSurfaceCoverageGate`, `dispatchCompletenessGate`, `blockedClarifications`, `baselineAutoRefreshGate`, `claimFreshnessGate`, `performance`, `heuristicProof`를 반드시 기록합니다. `baseline-snapshot.json`에는 같은 run에서 사용한 cumulative/iteration/current score snapshot과 다음 반복 승격 후보를 저장합니다. 둘 다에 중복 기록할 필요는 없지만, `report.md`와 JSON artifact는 같은 canonical metadata를 참조해야 합니다.
 
 `.claude/tigerkit/`은 generated branch-local working memory이며 repo-wide durable knowledge가 아닙니다.
 
@@ -786,7 +788,7 @@ newIterationImprovementClaimAllowed = false
 
 A concrete run must recompute these fields from its actual `dispatchPlan`, credited `dispatchSkips`, deterministic stage count, and run procedure step count. Do not copy the target proof as run proof when actual run metadata differs.
 
-The run receipt or manifest must record the measured proxy fields when a gap run claims performance improvement. `measurementMethod` defaults to `contract-derived-critical-path-proxy` unless actual wall-clock instrumentation exists. Do not claim speed success from vague phrases such as `expected`, `estimated`, or `likely`; success requires recorded cumulative baseline, iteration baseline, current score, score direction, and both improvement ratios. Do not use the fixed cumulative baseline alone to claim iteration speed improvement.
+`report.md` or JSON artifact must record the measured proxy fields when a gap run claims performance improvement. `measurementMethod` defaults to `contract-derived-critical-path-proxy` unless actual wall-clock instrumentation exists. Do not claim speed success from vague phrases such as `expected`, `estimated`, or `likely`; success requires recorded cumulative baseline, iteration baseline, current score, score direction, and both improvement ratios. Do not use the fixed cumulative baseline alone to claim iteration speed improvement.
 
 `dispatchSkips` may contribute to speed proof only when each credited skip records `agent`, `reason`, `sourceClass`, `credited: true`, `criticalPathDelta`, and `evidenceCoveragePreserved: true`. A skip caused by missing or ambiguous evidence may reduce agent dispatch, but it cannot be credited to speed improvement unless the run still preserves the required evidence coverage for the selected `analysisDepth`.
 
@@ -836,47 +838,33 @@ Implementation 개선 작업에서는 `redesign -> analysis -> review -> feedbac
 
 ## Output
 
-기본 stdout은 summary receipt와 compact finding tables만 출력합니다.
+기본 stdout은 사용자가 바로 행동할 수 있는 receipt만 출력합니다.
 
 ```text
-Gap Review 시작: <GAP-ID>
+Gap Review 완료: <GAP-ID>
 Branch Scope: <branch-key>
-품질 gate: evidence precision + producer evidence + ambiguity + JudgeMerger
-분석 깊이: <direct|bounded|expanded|exhaustive-capped>
-확장 이유: <none|summary>
-검증 강화: <none|targeted-red-team>
-상태: 완료
+결과: P0 <count> / P1 <count> / P2 <count> / Source Conflicts <count> / Clarification Needed <count>
 Report: .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md
-성능 증명: cumulative <ratio>x / iteration <ratio>x by <measurementMethod>
-누적 개선 증명: FP <ratio>x / FN <ratio>x / speed <ratio>x / depth <ratio>x
-반복 개선 증명: FP <ratio>x / FN <ratio>x / speed <ratio>x / depth <ratio>x
-Baseline: cumulative <sourceRef> / iteration <sourceRef>
-Baseline refresh: <pass|blocked> from <registryPath>
-Proof freshness: <pass|blocked>
-
-Findings:
-- P0: <count>
-- P1: <count>
-- P2: <count>
+다음 행동: <G1 먼저 수정|Q1 확인 필요|없음>
 
 Actionable Findings:
-| Ref | Sev | 요약 | 의미 | Required change |
-| --- | --- | --- | --- | --- |
-| G1 | P1 | <final finding 1줄 요약> | <사용자/제품 관점 영향 1줄> | <수정 방향 1줄> |
-
-Rejected/Downgraded:
-| Ref | Reason | 요약 | 왜 final gap 아님 |
+| Ref | Sev | 요약 | Required change |
 | --- | --- | --- | --- |
-| R1 | missing_evidence | <observation 1줄 요약> | <reject/downgrade 이유 1줄> |
+| G1 | P1 | <final finding 1줄 요약> | <수정 방향 1줄> |
 
-Source Conflicts: <count>
-Clarification Needed: <count>
-Rejected/Downgraded: <count>
+Clarification Needed:
+| Ref | 질문 | 추천 |
+| --- | --- | --- |
+| Q1 | <확인 질문 1줄> | <추천 1줄> |
 ```
 
-`Actionable Findings` table에는 JudgeMergerAgent가 accept한 P0/P1/P2 final finding만 출력합니다. 각 row는 run-local Ref, severity, gap 요약, 사용자/제품 관점 의미, requiredChange 1줄 요약만 포함합니다. final finding이 없으면 `없음` 1줄을 출력합니다.
+`Actionable Findings` table에는 JudgeMergerAgent가 accept한 P0/P1/P2 final finding만 출력합니다. 각 row는 run-local Ref, severity, gap 요약, requiredChange 1줄 요약만 포함합니다. final finding이 없으면 table을 생략합니다.
 
-`Rejected/Downgraded` table에는 final gap이 아닌 observation을 간략히 출력합니다. 각 row는 run-local Ref, reason, observation 요약, final gap이 아닌 이유 1줄만 포함합니다. 항목이 없으면 `없음` 1줄을 출력합니다. `missing_producer_evidence` row는 필요한 producer evidence와 `Q<N>` 확인 요청 Ref를 함께 언급합니다. P3/nit/duplicate/unverifiable/source_conflict 같은 rejected item을 confirmed defect처럼 쓰면 안 됩니다.
+`Clarification Needed` table에는 사용자가 답해야 다음 행동이 가능한 질문만 출력합니다. 각 row는 run-local Ref, 질문 1줄, 추천 1줄만 포함합니다. 확인 질문이 없으면 table을 생략합니다.
+
+Default stdout에는 quality gate, analysis depth, 확장 이유, verification escalation, performance proof, heuristic proof, baseline refresh, proof freshness, rejected/downgraded observation 목록, artifact file list를 출력하지 않습니다. 이 정보는 `report.md`와 JSON artifact에 저장합니다.
+
+Rejected/Downgraded observation은 기본 stdout에 출력하지 않습니다. `missing_producer_evidence`처럼 사용자가 확인해야 하는 항목은 `Clarification Needed`의 `Q<N>`으로 요약하고, 상세 rejected reason과 producer evidence 상태는 `report.md`에 둡니다. P3/nit/duplicate/unverifiable/source_conflict 같은 rejected item을 confirmed defect처럼 쓰면 안 됩니다.
 
 유저향 compact table에는 긴 canonical ID를 column으로 직접 노출하지 않습니다. canonical ID는 JSON artifact의 `id`와 `displayRef` mapping, 또는 `report.md` 상세/참조 영역에서 확인할 수 있어야 합니다.
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -89,7 +89,7 @@
       "id": 3,
       "name": "gap-performance-proof",
       "prompt": "Evaluate /tk:gap performance proof requirements for the single /tk:gap execution. Do not write files.",
-      "expected_output": "Should require a measured performance proof rather than a vague estimate. Should use the contract-derived critical path proxy when runtime wall-clock instrumentation is unavailable. Should require speed proof to record cumulativeBaseline, refreshed origin/main iterationBaseline, currentScore, cumulativeImprovementRatio, iterationImprovementRatio, score direction lower_is_better, performance.agentCriticalPathGroups, performance.deterministicStageGroups, performance.runProcedureSteps, performance.measurementMethod, baselineAutoRefreshGate, baseline-snapshot.json, and heuristicProof.speed in the run receipt or manifest. Current optimized contract target should show cumulative baseline 87.1, iteration baseline 50.3, currentScore <= 50.3, cumulativeImprovementRatio = 87.1 / 50.3 = 1.731... with display ratio 1.73, and iterationImprovementRatio = 50.3 / 50.3 = 1.00 with no new iteration speed improvement claim by contract-derived-critical-path-proxy. Should calculate baseline and current with the same proxy weights. Credited dispatchSkips may count only when credited, criticalPathDelta, and evidenceCoveragePreserved are recorded. Should not claim success from phrases such as expected, estimated, or likely.",
+      "expected_output": "Should require a measured performance proof rather than a vague estimate. Should use the contract-derived critical path proxy when runtime wall-clock instrumentation is unavailable. Should require speed proof to record cumulativeBaseline, refreshed origin/main iterationBaseline, currentScore, cumulativeImprovementRatio, iterationImprovementRatio, score direction lower_is_better, performance.agentCriticalPathGroups, performance.deterministicStageGroups, performance.runProcedureSteps, performance.measurementMethod, baselineAutoRefreshGate, baseline-snapshot.json, and heuristicProof.speed in report.md or JSON artifacts. Current optimized contract target should show cumulative baseline 87.1, iteration baseline 50.3, currentScore <= 50.3, cumulativeImprovementRatio = 87.1 / 50.3 = 1.731... with display ratio 1.73, and iterationImprovementRatio = 50.3 / 50.3 = 1.00 with no new iteration speed improvement claim by contract-derived-critical-path-proxy. Should calculate baseline and current with the same proxy weights. Credited dispatchSkips may count only when credited, criticalPathDelta, and evidenceCoveragePreserved are recorded. Should not claim success from phrases such as expected, estimated, or likely.",
       "files": [
         "commands/gap.md",
         ".tigerkit/docs/output-contract.md",
@@ -141,19 +141,20 @@
       "id": 6,
       "name": "gap-final-receipt-single-execution",
       "prompt": "Evaluate /tk:gap stdout receipt for a completed run. Do not write files.",
-      "expected_output": "Should output analysis depth, expansion reasons, verification escalation, dispatch skip summary, Candidate Intake Gate summary, BaselineAutoRefreshGate status, ClaimFreshnessGate status, heuristic proof summary with cumulative and refreshed iteration FP/FN/speed/depth ratios, report path, P0/P1/P2 counts, source conflict count, clarification-needed count, rejected/downgraded count, numeric performance proof, and compact Actionable Findings and Rejected/Downgraded tables using short run-local Ref values instead of long canonical Candidate/Finding IDs. Should not output executed preset, recommended preset, or Strict executed as primary labels.",
+      "expected_output": "Should output a compact user receipt with run ID, branch scope, P0/P1/P2 counts, source conflict count, clarification-needed count, report path, and one next action. Should include compact Actionable Findings only when accepted findings exist, and compact Clarification Needed only when user confirmation is needed. Should use short run-local Ref values instead of long canonical Candidate/Finding IDs. Should not print analysis depth, expansion reasons, verification escalation, dispatch skip summary, Candidate Intake Gate summary, BaselineAutoRefreshGate status, ClaimFreshnessGate status, heuristic proof ratios, rejected/downgraded observation lists, numeric performance proof, or artifact file lists in default stdout. Those details should remain in report.md or JSON artifacts. Should not output executed preset, recommended preset, or Strict executed as primary labels.",
       "files": [
         "commands/gap.md",
         ".tigerkit/docs/output-contract.md"
       ],
       "expectations": [
-        "Receipt is depth-based",
-        "Includes dispatch skip and Candidate Intake Gate summaries",
-        "Includes BaselineAutoRefreshGate status",
-        "Includes ClaimFreshnessGate status",
-        "Includes heuristic proof summary with cumulative and iteration FP/FN/speed/depth ratios",
+        "Receipt is compact and action-oriented",
+        "Includes report path and next action",
+        "Includes finding and clarification counts",
+        "Keeps proof and baseline details out of default stdout",
+        "Keeps rejected/downgraded observation list out of default stdout",
+        "Keeps artifact file list out of default stdout",
         "No primary preset labels",
-        "Compact tables preserved",
+        "Compact tables are conditional",
         "Compact tables use short Ref values instead of long canonical IDs"
       ]
     },


### PR DESCRIPTION
Issue: Fixes #62

Summary:
- `/tk:gap` 기본 stdout을 사용자가 바로 행동할 receipt 중심으로 축소했습니다.
- proof, baseline, rejected observation, artifact inventory는 `report.md`와 JSON artifact에 남기도록 계약을 정리했습니다.
- 6개 gap artifact가 필요한 audit/machine surface임을 artifact layout에 명시했습니다.

Validation:
- [x] `claude plugin validate .claude-plugin/plugin.json` (passed with existing CLAUDE.md warning)
- [x] `claude plugin validate .`
- [x] `python3 -m json.tool evals/evals.json >/dev/null`
- [x] `git diff --check`

Notes:
- 변경 범위는 docs/rules/eval fixture에 한정했습니다.
- 보안/credential/deploy/release automation 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
