### PR TITLE
chore: bump plugin patch version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "branch-scoped spec, adaptive contract-based gap review, durable reflection, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "7.2.12",
+  "version": "7.2.13",
   "author": {
     "name": "MTGVim"
   },


### PR DESCRIPTION
Summary:
- Issue PR #63 was merged.
- Standalone marketplace patch bump is required because latest `origin/main` commit is not a plugin version bump commit.

Version:
- Bumped plugin patch version from 7.2.12 to 7.2.13 because origin/main latest commit is not a version bump commit.

Validation:
- [x] `claude plugin validate .claude-plugin/plugin.json` (passed with existing CLAUDE.md warning)
- [x] `claude plugin validate .`
- [x] `python3 -m json.tool evals/evals.json >/dev/null`
- [x] `git diff --check`

Notes:
- Diff only changes `.claude-plugin/plugin.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
