### PR TITLE
feat: add locked source intake to gap review

### DIFF
--- a/.claude/rules/review/gap-analysis.md
+++ b/.claude/rules/review/gap-analysis.md
@@ -87,6 +87,7 @@ Required handling:
 - Use compact tables for ambiguity resolution.
 - For UI decisions, include TUI/ASCII prototypes when useful. Right borders must align; account for Korean full-width glyphs and padding.
 
+
 ## GAP-008: Check current implementation freshness before comparing
 
 When the target means `current implementation`, current working tree, current branch, or local checkout:
@@ -180,3 +181,23 @@ When the target means `current implementation`, current working tree, current br
 - `heuristicProof.analysisDepth` must prove hard-trigger coverage before risk-score tie-breaker use, including target-surface and dispatch-completeness backstops.
 - If any subproof is missing or below threshold, set `heuristicProof.claimAllowed: false` and avoid claiming combined improvement.
 - Default user-facing `/tk:gap` output must not expose this proof surface.
+
+## GAP-018: Use source-by-source locked intake for large source sets
+
+When a `/tk:gap` input includes many independent sources such as multiple breakpoints, variants, or auxiliary case sets:
+
+- Do not collapse all sources into one untracked batch when that would blur independent verification.
+- First state the preferred delivery format when asking for or organizing the source set.
+- Process sources one at a time when practical: record raw reference, source_type, access status, derived Contract, comparison result, and clarification state separately.
+- Lock each source after measurement and comparison. If later material changes that source, treat it as a new source or superseding source instead of silently mutating the locked basis.
+- If the source set is small or inherently one bundle, batch intake remains allowed.
+
+## GAP-019: Separate design source trust axes
+
+For design evidence:
+
+- Treat structural or metadata evidence as `source_type=structural_context`. Examples include frame/node structure, text layers, design tokens, component hierarchy, variant metadata, exported specs, or owner-confirmed values.
+- Treat screenshots, screen recordings, raster exports, and scaled visual captures as `source_type=visual_capture`.
+- Use `visual_capture` for layout, composition, visible state, hierarchy, and presence checks.
+- Do not confirm color, spacing, dimensions, typography scale, or other numeric design values from `visual_capture` alone because capture scale, compression, rendering, and sampling can distort them.
+- Numeric design values require structural/context evidence, design tokens, or explicit user/source confirmation. Existing implementation may support comparison or inference, but is not a design SOT by itself. If still insufficient, create `ClarificationNeeded` or reject as `unverifiable` instead of accepting a final finding.

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -53,6 +53,8 @@ Items:
 - candidate의 file:line, module-path, rendered output evidence는 JudgeMergerAgent queue 진입 전에 현재 target surface에서 read-back으로 재확인합니다.
 - producer-absence claim은 producer-side evidence gate를 통과해야 합니다.
 - user-provided source, referenced source, repo에서 접근 가능한 API contract/schema/endpoint/serializer/data model이 있으면 사용자에게 묻기 전에 먼저 확인합니다.
+- source set이 크면 source-by-source locked intake를 권장하고, report/run record에는 source별 source_type, access status, lock status, derived Contract 상태를 분리해 남깁니다.
+- design evidence는 `structural_context`와 `visual_capture`를 구분합니다. `visual_capture`만으로 색·간격·치수 같은 numeric design value를 confirmed contract로 확정하지 않습니다. 기존 구현은 대조·추론 보조로만 쓰며 design SOT가 아닙니다.
 - consumer-only fallback/default/mapper evidence는 producer absence accepted finding이나 `SourceConflict`로 승격하지 않습니다.
 - `missing_producer_evidence`는 숨기지 않습니다. 기본 stdout에서는 `Clarification Needed`로 짧게 보여주고, 확인한 producer surface와 missing evidence 상세는 `report.md`에 둡니다.
 - ambiguity와 source conflict는 Judge accept path 전에 `Clarification Needed` 또는 `SourceConflict`로 기록합니다.
@@ -117,6 +119,7 @@ reportPath
 runJsonPath
 maintainerProofEnabled: false
 sourceRefs
+sourceIntake
 counts
 findings
 clarifications
@@ -144,6 +147,8 @@ nextAction
 
 ## Next Action
 ```
+
+`## Sources Used`에는 source별 `source_type`, access status, lock status, raw reference, derived Contract 상태를 구분해 둡니다. 대량 source는 source 단위 lock 시점을 남기고, visual capture가 numeric design value의 단독 근거인지 여부를 표시합니다.
 
 `## Actionable Findings`에는 accepted P0/P1/P2 final finding만 둡니다.
 

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -66,6 +66,8 @@ Plugin namespace는 `/tk:*`입니다. 해당 workflow를 명시한 자연어 요
 - Product Spec, Design Spec, Design System Spec, Engineering Constraint, QA Acceptance Criteria, Analytics Contract를 Contract로 normalize해 비교합니다.
 - active/confirmed Spec Patch item을 기본 참조합니다.
 - 기본 호출은 user-provided references, target hints, Current Implementation 후보, 위험 신호를 먼저 skim한 뒤 단일 `/tk:gap` 실행로 실행합니다.
+- 다중 breakpoint/variant/case처럼 source set이 크면 원하는 전달 포맷을 먼저 제안하고 source 단위로 수집·측정·대조·lock한 뒤 다음 source로 진행하는 경로를 권장합니다. source가 적으면 기존 일괄 경로를 유지할 수 있습니다.
+- design source는 `structural_context`와 `visual_capture` 신뢰 축을 분리합니다. `visual_capture`는 layout/구성 확인에 쓰고, 색·간격·치수 같은 수치 값은 구조/메타 자료, design token, 또는 confirmed source 없이는 확정하지 않습니다. 기존 구현은 대조·추론 보조로만 씁니다.
 - 기본 산출물은 `report.md`와 `run.json`입니다.
 - 기본 stdout은 run 결과, finding/clarification count, report path, run.json path, next action만 출력합니다.
 - 전체 report는 `--print-report`가 있을 때만 출력합니다.

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -50,6 +50,7 @@ TigerKit 자체 성능 개선, baseline, heuristic proof, performance proof, fal
 - current implementation 비교 전에는 integration branch freshness를 확인합니다.
 - 모든 final finding은 analysis depth와 관계없이 evidence precision, producer evidence, ambiguity, JudgeMerger gate를 통과해야 합니다.
 - 사용자가 files/scope를 명시하지 않는 기본 흐름은 issue ticket, design node link, screenshot, pasted notes 같은 user-provided references에서 target hints를 추출합니다.
+- source set이 커서 다중 breakpoint/variant/case를 한 번에 받으면 source-by-source locked intake를 권장합니다. 먼저 원하는 전달 포맷을 명시하고, source 단위로 수집·측정·대조·lock한 뒤 다음 source로 진행합니다. source가 적고 독립 검증이 흐려지지 않으면 기존 일괄 intake를 유지할 수 있습니다.
 - changed files는 primary scope가 아니라 Current Implementation 후보 evidence입니다.
 - Product Spec, Design Spec, API contract, source priority, owner decision의 ambiguity는 명확해 보여도 user consent 전에는 confirmed contract로 승격하지 않습니다.
 - visible UI copy는 confirmed contract와 exact match가 필요합니다.
@@ -89,6 +90,24 @@ TigerKit 자체 성능 개선, baseline, heuristic proof, performance proof, fal
 - Design review skill
 - quality mode
 - preset 추천
+
+## Source intake and design evidence trust
+
+대량 source intake에서는 독립 검증과 사용자 확정 시점을 보존합니다.
+
+- source set이 다중 breakpoint, variant, 보조 case set처럼 커 보이면 먼저 전달 포맷을 제안합니다.
+- source 단위로 raw reference, derived Contract, current implementation 비교 결과, clarification 여부를 분리해 기록합니다.
+- 각 source는 측정·대조가 끝난 시점에 lock하고, lock 후 새 자료가 오면 같은 source를 조용히 덮어쓰지 않고 추가 source 또는 superseding source로 다룹니다.
+- locked intake는 누락·과적을 줄이기 위한 권장 경로입니다. source가 적거나 서로 의존하는 단일 bundle이면 기존 일괄 intake를 사용할 수 있습니다.
+
+Design source는 trust axis를 분리합니다.
+
+| source_type | 역할 | 제한 |
+| --- | --- | --- |
+| `structural_context` | frame/node 구조, text layer, token/metadata, component hierarchy, variant 관계 확인 | 접근 불가하거나 불완전하면 missing evidence로 표시 |
+| `visual_capture` | layout, 구성, hierarchy, state 비교의 보조 근거 | 색, 간격, 치수 같은 수치 값을 단독 확정하지 않음 |
+
+색·간격·치수 같은 numeric design value는 구조/메타 자료, design token, 또는 명시된 confirmed source가 필요합니다. 기존 구현은 대조·추론 보조로만 쓰며 단독 design SOT가 아닙니다. visual capture만 있거나 배율/렌더링 왜곡 가능성이 남으면 수치 단정 대신 `Clarification Needed` 또는 rejected `unverifiable`로 기록합니다.
 
 ## Branch-local storage
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -323,6 +323,29 @@
         "Skips duplicate insights",
         "Prints apply summary"
       ]
+    },
+    {
+      "id": 14,
+      "name": "gap-source-by-source-intake-and-design-trust-axis",
+      "prompt": "Evaluate /tk:gap behavior when the user provides many design sources across breakpoints, variants, and auxiliary cases, including both structural metadata and visual captures. Do not write files.",
+      "expected_output": "Should recommend source-by-source locked intake when a large source set would blur independent verification: first state the preferred delivery format, then collect, measure, compare, and lock each source before proceeding. It should preserve small-source batch intake when independent verification is not at risk. It should classify design evidence into structural_context and visual_capture, use visual_capture only for layout/composition/state/hierarchy support, and avoid confirming color, spacing, dimensions, typography scale, or other numeric design values from visual_capture alone. Numeric design values should require structural metadata, design tokens, or explicit source/user confirmation, with existing implementation used only as comparison or inference support rather than design SOT; otherwise the result should become Clarification Needed or rejected unverifiable rather than an accepted finding.",
+      "files": [
+        "commands/gap.md",
+        ".claude/rules/review/gap-analysis.md",
+        ".tigerkit/docs/usage.md",
+        ".tigerkit/docs/output-contract.md"
+      ],
+      "expectations": [
+        "Recommends source-by-source locked intake for large source sets",
+        "States preferred delivery format before large intake",
+        "Locks each source after measurement and comparison",
+        "Preserves batch intake for small or inherently bundled source sets",
+        "Separates structural_context from visual_capture",
+        "Uses visual_capture for layout and composition only",
+        "Does not confirm numeric design values from visual_capture alone",
+        "Requires structural metadata, design tokens, or explicit confirmation for numeric design values",
+        "Creates Clarification Needed or rejected unverifiable when numeric evidence is insufficient"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fixes #67.
- Adds source-by-source locked intake guidance for large `/tk:gap` source sets.
- Separates design evidence trust axes so visual captures do not confirm numeric design values alone.
- Updates usage/output docs and eval fixture coverage for the new behavior.

## Validation
- [x] `claude plugin validate .claude-plugin/plugin.json` (passed with existing CLAUDE.md warning)
- [x] `claude plugin validate .`
- [x] `python3 -m json.tool evals/evals.json >/dev/null`
- [x] `git diff --check`

## Notes
- No security, secret, workflow, deploy, or release scope changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)