### PR TITLE
chore: bump plugin patch version

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "branch-scoped spec, user-facing contract-based gap review, durable reflection, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "7.2.15",
+  "version": "7.2.16",
   "author": {
     "name": "MTGVim"
   },


### PR DESCRIPTION
## Summary
- Bumps `.claude-plugin/plugin.json` from 7.2.15 to 7.2.16 after the merged issue PR #68.

Version:
- Bumped plugin patch version from 7.2.15 to 7.2.16 because origin/main latest commit is not a version bump commit.

## Validation
- [x] `claude plugin validate .claude-plugin/plugin.json` (passed with existing CLAUDE.md warning)
- [x] `claude plugin validate .`
- [x] `python3 -m json.tool evals/evals.json >/dev/null`
- [x] `git diff --check`

## Notes
- Standalone marketplace patch-bump fallback only; no functional behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)