### PR TITLE
feat: align TigerKit v8 launch contracts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "sealed GAP workflow, human-approved launch, durable reflection, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "7.4.2",
+  "version": "8.0.0",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -21,11 +21,12 @@ TigerKit은 branch-local working memory와 durable insight를 분리합니다.
           WF-YYYYMMDD-HHmmss-RAND.md
           current.md
           GAP-YYYYMMDD-HHmmss-RAND.md
-        launches/
-          LCH-YYYYMMDD-HHmmss-RAND/
-            report.md
-            run.json
-            reflect-report.md
+        launch/
+          LCH-YYYYMMDD-HHmmss-RAND.md
+          current.md
+        reflect/
+          RFL-YYYYMMDD-HHmmss-RAND.md
+          current.md
         runs/
           gap/
             GAP-YYYYMMDD-HHmmss-RAND/
@@ -65,9 +66,10 @@ TigerKit은 branch-local working memory와 durable insight를 분리합니다.
 | `.claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md` | `/tk:gap`이 `GAP_READY`일 때 만드는 sealed launch workflow archive입니다. | branch-local |
 | `.claude/tigerkit/branches/<branch-key>/gap/current.md` | 최신 sealed launch workflow copy입니다. hash seal의 authoritative source는 archive workflow 파일입니다. | branch-local pointer |
 | `.claude/tigerkit/branches/<branch-key>/gap/<GAP-ID>.md` | `/tk:gap`이 `GAP_BLOCKED`일 때 만드는 blocked report입니다. workflow block을 포함하지 않습니다. | branch-local |
-| `.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/report.md` | `/tk:launch` 실행 또는 abort report입니다. | branch-local execution |
-| `.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/run.json` | launch status, task/gate 결과, abort code, commit decision을 보존하는 최소 run record입니다. | branch-local execution |
-| `.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/reflect-report.md` | launch postflight에서 `/tk:reflect`가 읽을 수 있게 남기는 generated report입니다. durable apply가 아닙니다. | branch-local generated |
+| `.claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md` | `/tk:launch` 실행 또는 abort report입니다. | branch-local execution |
+| `.claude/tigerkit/branches/<branch-key>/launch/current.md` | launch status, task/gate 결과, abort code, commit decision을 보존하는 최소 run record입니다. | branch-local execution |
+| `.claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md` | `/tk:reflect` generated report archive입니다. `tigerkit-reflect-report` block을 포함합니다. durable apply가 아닙니다. | branch-local generated |
+| `.claude/tigerkit/branches/<branch-key>/reflect/current.md` | 최신 reflect report copy입니다. | branch-local pointer |
 | `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md` | `/tk:gap --review` 사용자가 읽는 compatibility gap report 본문입니다. Actionable Findings, Clarification Needed, next action 중심입니다. | branch-local |
 | `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/run.json` | `/tk:gap --review` 후속 대화와 기계 처리를 위한 최소 run record입니다. user-facing short Ref와 canonical ID mapping을 보존합니다. | branch-local |
 | `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/maintainer-proof/` | `--maintainer-proof`가 명시된 경우에만 생성하는 self-eval/performance proof, gate/debug metadata, baseline snapshot 영역입니다. | branch-local maintainer-only |
@@ -81,7 +83,17 @@ TigerKit은 branch-local working memory와 durable insight를 분리합니다.
 
 ## 기본 `/tk:gap` artifact
 
-기본 gap run의 필수 artifact는 `report.md`와 `run.json`만입니다.
+기본 `/tk:gap`은 v8 sealed workflow builder입니다. launch 가능 여부에 따라 아래 중 하나를 씁니다.
+
+```text
+.claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md       # GAP_READY archive
+.claude/tigerkit/branches/<branch-key>/gap/current.md       # latest GAP_READY copy
+.claude/tigerkit/branches/<branch-key>/gap/<GAP-ID>.md      # GAP_BLOCKED report
+```
+
+`GAP_READY` archive는 사람용 report와 정확히 하나의 `tigerkit-gap-status` block, 정확히 하나의 `tigerkit-launch-workflow` block을 포함합니다. `GAP_BLOCKED` report는 `tigerkit-gap-status` block만 포함하고 `tigerkit-launch-workflow` block을 포함하지 않습니다.
+
+`/tk:gap --review` compatibility mode만 v7 review layout을 씁니다.
 
 ```text
 .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/
@@ -89,26 +101,9 @@ TigerKit은 branch-local working memory와 durable insight를 분리합니다.
   run.json
 ```
 
-`report.md`는 사용자가 읽는 표면입니다. `run.json`은 후속 대화, short Ref mapping, 최소 machine-readable record를 위한 표면입니다. proof/debug artifact는 기본 artifact가 아니며, 기본 stdout/report에 섞이면 안 됩니다.
+`--maintainer-proof`가 있을 때만 `runs/gap/<GAP-ID>/maintainer-proof/` 아래 proof/debug artifact를 추가할 수 있습니다.
 
-기본 `run.json`은 아래 성격의 정보만 가집니다.
-
-- run identity
-- branch scope
-- source refs와 access status
-- P0/P1/P2 count
-- source conflict count
-- clarification-needed count
-- findings
-- clarifications
-- rejected summary
-- displayRef mapping
-- checked evidence refs
-- report/run path
-- next action
-- `maintainerProofEnabled: false`
-
-기본 gap run은 아래 파일을 필수로 만들지 않습니다.
+기본 gap workflow/report는 아래 self-eval/proof/debug metadata를 요구하지 않습니다.
 
 ```text
 input-manifest.json
@@ -119,7 +114,7 @@ baseline-snapshot.json
 proof.json
 ```
 
-기본 gap run의 `report.md`와 `run.json`은 아래 self-eval/proof/debug metadata를 요구하지 않습니다.
+기본 gap workflow/report와 `/tk:gap --review` compatibility run은 아래 self-eval/proof/debug metadata를 요구하지 않습니다.
 
 - `qualityGates`
 - `heuristicProof`

--- a/.tigerkit/docs/branch-local-contract.md
+++ b/.tigerkit/docs/branch-local-contract.md
@@ -26,7 +26,8 @@ Sealed workflow 기본 위치:
 Launch run 기본 위치:
 
 ```text
-.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/
+.claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+.claude/tigerkit/branches/<branch-key>/launch/current.md
 ```
 
 Gap Review compatibility 기본 위치:
@@ -119,11 +120,11 @@ Tiger Kit does not read or write files outside the current worktree by default.
 
 ## `/tk:gap` branch-local storage
 
-`/tk:gap`은 반드시 current worktree root 아래 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/`에 저장합니다.
+기본 `/tk:gap`은 v8 sealed workflow builder입니다. `GAP_READY`이면 `.claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md` archive와 `gap/current.md` copy를 쓰고, `GAP_BLOCKED`이면 `.claude/tigerkit/branches/<branch-key>/gap/<GAP-ID>.md` blocked report를 쓰며 launch workflow block은 쓰지 않습니다.
 
-기본 `/tk:gap` 필수 파일은 `report.md`와 `run.json`입니다. `report.md`는 사용자가 읽는 표면이고, `run.json`은 후속 대화와 기계 처리를 위한 최소 run record입니다.
+`/tk:gap --review` compatibility mode만 v7 review layout인 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md`와 `run.json`을 씁니다.
 
-상세 artifact layout은 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다. 상세 stdout/report/run.json 계약은 `.tigerkit/docs/output-contract.md`의 `/tk:gap default stdout` 섹션을 기준으로 합니다.
+상세 artifact layout은 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다. 상세 stdout/report 계약은 `.tigerkit/docs/output-contract.md`를 기준으로 합니다.
 
 `.claude/tigerkit/`은 generated branch-local working memory이며 repo-wide durable knowledge가 아닙니다.
 
@@ -146,14 +147,15 @@ Tiger Kit does not read or write files outside the current worktree by default.
 `/tk:launch`는 실행 또는 abort 결과를 아래에 저장합니다.
 
 ```text
-.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/report.md
-.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/run.json
-.claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/reflect-report.md
+.claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+.claude/tigerkit/branches/<branch-key>/launch/current.md
+.claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
+.claude/tigerkit/branches/<branch-key>/reflect/current.md
 ```
 
 - launch run은 workflow hash, task/gate 결과, abort code, commit decision을 기록합니다.
-- `reflect-report.md`는 generated branch-local trace이며 durable apply가 아닙니다.
-- `branch-state.json`에는 `lastLaunchId`, `lastLaunchPath`, `lastLaunchStatus`를 기록할 수 있습니다.
+- reflect archive와 `reflect/current.md`는 generated branch-local trace이며 durable apply가 아닙니다.
+- `branch-state.json`에는 `lastLaunchId`, `lastLaunchPath`, `lastLaunchStatus`, `lastReflectId`, `lastReflectPath`를 기록할 수 있습니다.
 
 ## `/tk:handoff` branch-local context
 
@@ -176,7 +178,8 @@ Tiger Kit does not read or write files outside the current worktree by default.
 최신 branch-local TigerKit artifact가 관측되면 handoff에 참조할 수 있습니다.
 
 - 최신 Spec Patch: `.claude/tigerkit/branches/<branch-key>/specs/SP-*.md`
-- 최신 Gap Run: `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md`
+- 최신 Gap Workflow: `.claude/tigerkit/branches/<branch-key>/gap/current.md`
+- 최신 Gap Review: `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md`
 - branch state: `.claude/tigerkit/branches/<branch-key>/branch-state.json`
 
 handoff는 branch-local artifact 자체를 durable rule로 승격하지 않습니다. 다음 작업자가 읽을 continuation 요약만 작성합니다.
@@ -205,7 +208,10 @@ Reflect는 current branch scope의 branch-local working memory를 읽습니다.
 
 ```text
 .claude/tigerkit/branches/<branch-key>/specs/
-.claude/tigerkit/branches/<branch-key>/runs/gap/
+.claude/tigerkit/branches/<branch-key>/gap/
+.claude/tigerkit/branches/<branch-key>/launch/
+.claude/tigerkit/branches/<branch-key>/reflect/
+.claude/tigerkit/branches/<branch-key>/runs/gap/  # only /tk:gap --review
 .claude/tigerkit/branches/<branch-key>/branch-state.json
 ```
 

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -81,7 +81,7 @@ Report: .claude/tigerkit/branches/<branch-key>/gap/<GAP-ID>.md
 
 ### `tigerkit-gap-status` block
 
-```yaml
+```tigerkit-gap-status
 status: GAP_READY | GAP_BLOCKED
 workflow_id: WF-YYYYMMDD-HHmmss-RAND | null
 workflow_path: .claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md | null
@@ -91,15 +91,54 @@ human_decisions: []
 missing_sources: []
 ```
 
+### `tigerkit-launch-workflow` block
+
+`GAP_READY` artifact는 정확히 하나의 named fenced block을 포함합니다. 이 block은 `/tk:launch`가 소비하는 sealed workflow contract입니다. `workflow_sha256`은 이 block 안에 넣지 않습니다.
+
+```tigerkit-launch-workflow
+version: 1
+workflow_id: WF-YYYYMMDD-HHmmss-RAND
+created_at: <ISO-8601>
+source_refs: []
+mission: <one sentence>
+scope: []
+non_goals: []
+human_decisions: []
+assumptions: []
+rejected_assumptions: []
+tasks:
+  - id: T1
+    title: <short title>
+    goal: <task goal>
+    files: []
+    depends_on: []
+    allowed_changes: []
+    forbidden_changes: []
+    success_conditions: []
+    verification: []
+    abort_conditions: []
+autopilot_policy:
+  allowed: false
+  max_recovery_attempts: 0
+  max_task_retries: 0
+  forbidden: []
+commit_policy:
+  mode: preflight_decision_required
+  allowed: false
+reflect_policy:
+  mode: generated_report_only
+  durable_apply_requires_preflight_approval: true
+```
+
 ### `tigerkit-launch-workflow` seal
 
-`workflow_sha256`은 단일 `tigerkit-launch-workflow` fenced block body의 SHA-256입니다.
+`workflow_sha256`은 단일 `tigerkit-launch-workflow` fenced block body의 SHA-256이며, `tigerkit-gap-status`와 `branch-state.json`에 기록하는 외부 seal입니다. `tigerkit-launch-workflow` block 내부에 자기참조 field로 넣지 않습니다.
 
 - opening fence와 closing fence line은 제외합니다.
 - block body는 LF로 정규화합니다.
 - hashing 전 final LF를 정확히 하나 보장합니다.
 - YAML-normalize 또는 key sort를 하지 않습니다.
-- archive workflow 파일이 authoritative입니다. `current.md`는 최신 copy입니다.
+- archive workflow 파일이 authoritative입니다. `current.md`는 최신 copy입니다. `/tk:launch`는 archive block hash, `current.md` block hash, branch-state hash가 일치하지 않으면 `WORKFLOW_HASH_MISMATCH`로 중단합니다.
 
 ## `/tk:gap --review` Output Contract
 
@@ -311,6 +350,24 @@ Concrete maintainer proof runs must recompute actual run proof from metadata bef
 - Phase 1에서 `--autopilot` recovery는 실행하지 않습니다.
 - commit은 preflight approval evidence 없이는 금지합니다.
 
+
+### `tigerkit-launch-receipt` block
+
+Launch report는 사람용 H2와 별도로 정확히 하나의 machine-readable block을 포함합니다.
+
+```tigerkit-launch-receipt
+version: 1
+launch_id: LCH-YYYYMMDD-HHmmss-RAND
+workflow_id: WF-YYYYMMDD-HHmmss-RAND
+workflow_path: .claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md
+workflow_sha256: <sha256>
+status: SUCCESS_NO_COMMIT | SUCCESS_COMMITTED | ABORTED | FAILED_PREFLIGHT
+abort_code: null
+commit_created: false
+reflect_report_path: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
+reflect_current_path: .claude/tigerkit/branches/<branch-key>/reflect/current.md
+```
+
 SUCCESS stdout:
 
 ```text
@@ -322,8 +379,10 @@ Workflow Hash: <sha256>
 Tasks: <done>/<total>
 Verification Gates: <passed>/<total>
 Commit: <created|skipped_preflight_required|skipped_not_requested>
-Report: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/report.md
-Reflect: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/reflect-report.md
+Report: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+Current: .claude/tigerkit/branches/<branch-key>/launch/current.md
+Reflect: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
+Reflect Current: .claude/tigerkit/branches/<branch-key>/reflect/current.md
 다음 행동: <없음|reflect 제안 검토|commit 승인 필요>
 ```
 
@@ -339,8 +398,10 @@ Abort Code: <CODE>
 원인: <한글 1줄>
 Completed Tasks: <done>/<total>
 Failed Gate: <VG-ID|없음>
-Report: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/report.md
-Reflect: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/reflect-report.md
+Report: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+Current: .claude/tigerkit/branches/<branch-key>/launch/current.md
+Reflect: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
+Reflect Current: .claude/tigerkit/branches/<branch-key>/reflect/current.md
 다음 행동: <human decision|workflow 재생성|scope 조정|검증 실패 수정>
 ```
 
@@ -374,6 +435,22 @@ Abort code 목록:
 - 근거가 부족한 후보는 `Needs more evidence`로 남기고 durable rule로 승격하지 않습니다.
 - reflect 처리 직후 `/tk:meta-feedback`을 proposal-only로 함께 제출합니다.
 - `--no-meta-feedback` 또는 `--meta-feedback=false`가 있으면 meta-feedback 제출을 생략합니다.
+
+
+### `tigerkit-reflect-report` block
+
+Reflect report는 정확히 하나의 machine-readable block을 포함합니다.
+
+```tigerkit-reflect-report
+version: 1
+reflect_id: RFL-YYYYMMDD-HHmmss-RAND
+workflow_id: WF-YYYYMMDD-HHmmss-RAND
+launch_id: LCH-YYYYMMDD-HHmmss-RAND
+mode: generated_report_only | durable_apply
+applied: []
+skipped: []
+proposal_only: []
+```
 
 기본 stdout:
 

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -115,7 +115,7 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 - subagent는 candidate만 생성하고 JudgeMergerAgent만 final finding을 확정합니다.
 - final finding은 P0/P1/P2만 포함합니다.
 - P3/nit/duplicate/unverifiable/source_conflict는 final finding이 아닙니다.
-- run artifact는 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/` 아래에 저장합니다.
+- `/tk:gap --review` run artifact는 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/` 아래에 저장합니다. 기본 `/tk:gap` sealed workflow는 `.claude/tigerkit/branches/<branch-key>/gap/` 아래에 저장합니다.
 - 유저향 compact table은 run-local short Ref(`G1`, `R1`, `C1`, `Q1`)를 우선 표시합니다.
 
 ### `/tk:launch`

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -130,11 +130,13 @@ Design source는 trust axis를 분리합니다.
 
 ## Branch-local storage
 
-반드시 current worktree root 아래 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/`에 저장합니다.
+기본 `/tk:gap`은 current worktree root 아래 `.claude/tigerkit/branches/<branch-key>/gap/`에 저장합니다.
 
-기본 `/tk:gap` 필수 파일은 `report.md`와 `run.json`입니다. `report.md`는 사용자가 읽는 표면이고, `run.json`은 후속 대화와 기계 처리를 위한 최소 run record입니다.
+- `GAP_READY`: `.claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md` archive와 `gap/current.md` copy를 씁니다.
+- `GAP_BLOCKED`: `.claude/tigerkit/branches/<branch-key>/gap/<GAP-ID>.md` blocked report를 쓰고 `tigerkit-launch-workflow` block은 쓰지 않습니다.
+- `/tk:gap --review`: v7 compatibility layout인 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md`와 `run.json`을 씁니다.
 
-상세 artifact layout은 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다. 상세 stdout/report/run.json 계약은 `.tigerkit/docs/output-contract.md`의 `/tk:gap default stdout` 섹션을 기준으로 합니다.
+상세 artifact layout은 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다. 상세 stdout/report 계약은 `.tigerkit/docs/output-contract.md`를 기준으로 합니다.
 
 `.claude/tigerkit/`은 generated branch-local working memory이며 repo-wide durable knowledge가 아닙니다.
 
@@ -142,19 +144,20 @@ Design source는 trust axis를 분리합니다.
 
 `--maintainer-proof`가 명시된 경우에만 `maintainer-proof/` 아래 self-eval/performance proof artifact를 생성하거나 요구합니다.
 
-기본 사용자 경로는 false-positive, false-negative, speed, analysis-depth improvement claim을 하지 않습니다. 기본 stdout/report/run.json에 proof/debug artifact 목록이나 self-eval metadata를 섞지 않습니다.
+기본 사용자 경로는 false-positive, false-negative, speed, analysis-depth improvement claim을 하지 않습니다. 기본 stdout/workflow/report와 `/tk:gap --review` run.json에 proof/debug artifact 목록이나 self-eval metadata를 섞지 않습니다.
 
 Maintainer-only artifact와 boundary는 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다. maintainer proof 노출 규칙은 `.tigerkit/docs/output-contract.md`를 기준으로 합니다.
 
 ## CLI options
 
-- default: 단일 `/tk:gap` 실행으로 실행하고 사용자-facing `report.md`와 `run.json`을 생성합니다.
+- default: source를 ground하고 ambiguity를 attack해 `GAP_READY` sealed workflow 또는 `GAP_BLOCKED` blocked report를 생성합니다.
+- `--review`: v7 Contract-based Gap Review compatibility mode입니다. 이 mode에서만 사용자-facing `report.md`와 `run.json`을 생성합니다.
 - `--analysis-depth <direct|bounded|expanded|exhaustive-capped>`: 품질 gate를 낮추지 않고 source discovery depth만 명시합니다. 기본 stdout에는 proof나 확장 이유 dump를 출력하지 않습니다.
 - `--spec <SP-ID>`: current branch scope의 `specs/index.json`에서만 resolve합니다.
 - `--spec <path>`: current worktree root 내부 path만 허용합니다.
 - `--no-specs`: active Spec Patch 자동 참조를 비활성화합니다.
-- `--print-report`: 저장된 `report.md` 본문을 stdout에도 출력합니다.
-- `--maintainer-proof`: maintainer/self-eval 전용 proof artifact를 `maintainer-proof/` 아래에 추가 생성합니다.
+- `--print-report`: 저장된 gap workflow/report 본문을 stdout에도 출력합니다.
+- `--maintainer-proof`: `/tk:gap --review` maintainer/self-eval 전용 proof artifact를 `maintainer-proof/` 아래에 추가 생성합니다.
 
 `--lite`와 `--strict`는 compatibility flag로만 기록하고 quality gate를 바꾸지 않습니다. `--legacy`, `TIGERKIT_GAP_LEGACY`, `--deep`, `--no-strict`는 active v8.0 mode가 아닙니다.
 
@@ -537,7 +540,7 @@ Analysis depth values:
 
 Depth selection uses hard triggers before risk-score tie-breakers. Explicit `--analysis-depth` may not lower the heuristic-required minimum depth for risky surfaces; lower requested depth is escalated internally without changing user-facing quality mode.
 
-기본 stdout/report/run.json은 depth proof를 요구하지 않습니다. `--maintainer-proof`에서만 analysis depth score, baseline, improvement ratio를 기록할 수 있습니다.
+기본 stdout/workflow/report와 `/tk:gap --review` run.json은 depth proof를 요구하지 않습니다. `--maintainer-proof`에서만 analysis depth score, baseline, improvement ratio를 기록할 수 있습니다.
 
 ## Maintainer proof contracts
 
@@ -614,7 +617,23 @@ Targeted verification: CriticalRedTeamAgent 1회만 수행.
 
 Implementation 개선 작업에서는 `redesign -> analysis -> review -> feedback incorporation` 루프를 사용할 수 있지만, 이것은 command contract를 갱신하고 검증하는 개발 절차입니다. `/tk:gap` runtime은 단일 실행과 capped verification을 유지합니다.
 
-## Run procedure
+## Default `/tk:gap` run procedure
+
+1. Emit start receipt with branch-key and planned `gap/<WF-ID>.md` or `gap/<GAP-ID>.md` path.
+2. Bind current worktree root, branch-key, user-provided references, target hints, prior specs, conversation decisions, and repo context.
+3. Load active Spec Patch unless `--no-specs` is present, but do not treat draft/conflict items as confirmed requirements.
+4. Ground sources by authority and access status: user decisions, URLs/tickets, docs, screenshots, current repo files, and existing branch-local TigerKit artifacts.
+5. Normalize confirmed requirements, non-goals, assumptions, rejected assumptions, human decisions, and missing sources.
+6. Attack ambiguity: contradictions, unresolved decisions, hidden dependencies, edge cases, failure modes, verification holes, and scope creep.
+7. Apply YAGNI trim: keep only work needed for the mission; cut/defer future extensibility or convert it to abort conditions.
+8. Build a sealed launch workflow with stable task IDs, task dependencies, allowed/forbidden changes, success conditions, verification gates, abort policy, commit policy, autopilot policy, and reflect policy.
+9. If unresolved launch-blocking items remain, materialize `GAP_BLOCKED` with blocked reasons, human decisions needed, missing sources, and no `tigerkit-launch-workflow` block.
+10. If launchable, materialize `GAP_READY` with exactly one `tigerkit-gap-status` block and exactly one `tigerkit-launch-workflow` block.
+11. Compute `workflow_sha256` from the `tigerkit-launch-workflow` block body and record it externally in `tigerkit-gap-status` and branch state. Do not put the hash inside the workflow block.
+12. Acquire branch lock, write archive artifact and `gap/current.md` copy for `GAP_READY`, or blocked report for `GAP_BLOCKED`; update branch/global index; release lock.
+13. Emit final stdout receipt matching `.tigerkit/docs/output-contract.md`.
+
+## `/tk:gap --review` compatibility run procedure
 
 1. Emit start receipt with GAP-ID, branch-key, planned report path, and planned run.json path.
 2. Bind current worktree root, branch-key, run-id, user-provided references, target hints, current implementation candidates, and integration freshness metadata.
@@ -631,27 +650,56 @@ Implementation 개선 작업에서는 `redesign -> analysis -> review -> feedbac
 13. Run JudgeMergerAgent once on final judge queue.
 14. Materialize Actionable Findings, Source Conflicts, Clarification Needed, and rejected summary.
 15. If `--maintainer-proof` is present, compute maintainer proof metadata and write `maintainer-proof/` artifacts.
-16. Acquire branch lock, write `report.md`, `run.json`, update branch/global index, release lock.
+16. Acquire branch lock, write `runs/gap/<GAP-ID>/report.md`, `runs/gap/<GAP-ID>/run.json`, update branch/global index, release lock.
 17. Emit final stdout receipt and compact tables.
 
 ## Output
 
-기본 stdout은 사용자가 바로 행동할 수 있는 receipt만 출력합니다.
+기본 stdout은 launch 가능 여부를 판단할 수 있는 receipt만 출력합니다.
 
 Interface 요약:
 
-- 완료한 단일 `/tk:gap` 실행의 run ID, branch scope, P0/P1/P2 count, Source Conflict count, Clarification Needed count를 출력합니다.
-- `report.md`와 `run.json` path, 다음 행동을 출력합니다.
-- Actionable Findings와 Clarification Needed table은 row가 있을 때만 compact하게 출력합니다.
-- 유저향 table은 run-local Ref(`G<N>`, `Q<N>`)를 우선 사용합니다.
-- `--print-report`가 있을 때만 저장된 `report.md` 본문을 stdout에도 출력합니다.
+- `GAP_READY` 또는 `GAP_BLOCKED`, branch scope, artifact path, 다음 행동을 출력합니다.
+- `GAP_READY`는 workflow path, workflow hash, task count, verification gate count, autopilot allowed, commit policy를 출력합니다.
+- `GAP_BLOCKED`는 blocked reason count, human decision count, missing source count, blocked report path를 출력합니다.
+- `GAP_READY` artifact는 정확히 하나의 `tigerkit-gap-status` block과 정확히 하나의 `tigerkit-launch-workflow` block을 포함합니다.
+- `GAP_BLOCKED` artifact는 `tigerkit-launch-workflow` block을 포함하지 않습니다.
+- `--print-report`가 있을 때만 저장된 workflow/report 본문을 stdout에도 출력합니다.
 - proof/debug/self-eval metadata와 rejected/downgraded 상세 목록은 기본 stdout에 출력하지 않습니다.
 
 Authoritative stdout contract는 `.tigerkit/docs/output-contract.md`의 `/tk:gap default stdout` 섹션입니다. artifact boundary는 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다.
 
-## Report shape
+## Default GAP artifact shape
 
-기본 `report.md`는 아래 H2를 사용합니다.
+`GAP_READY` archive와 `gap/current.md` copy는 아래 H2를 사용합니다.
+
+```md
+# TigerKit GAP Workflow: <WF-ID>
+
+## Status
+
+## Grounded Sources
+
+## Normalized Requirements
+
+## Ambiguity Attack
+
+## YAGNI Trim
+
+## Produced Launch Workflow
+
+## Human Decisions
+
+## Not Ready Reasons
+```
+
+`## Produced Launch Workflow`에는 정확히 하나의 `tigerkit-launch-workflow` fenced block을 둡니다. `workflow_sha256`은 이 block 안이 아니라 `tigerkit-gap-status`와 branch state에만 외부 seal로 둡니다.
+
+`GAP_BLOCKED` report는 같은 H2를 사용할 수 있지만 `## Produced Launch Workflow`에 workflow block을 쓰지 않고, `## Not Ready Reasons`와 `## Human Decisions`를 launch 차단 사유 중심으로 채웁니다.
+
+## `/tk:gap --review` report shape
+
+Compatibility `report.md`는 아래 H2를 사용합니다.
 
 ```md
 # Tiger Kit Gap Report: <GAP-ID>
@@ -681,7 +729,7 @@ Authoritative stdout contract는 `.tigerkit/docs/output-contract.md`의 `/tk:gap
 
 `## Not Accepted Summary`는 rejected/downgraded 상세 목록이 아니라 reason별 count와 사용자에게 의미 있는 짧은 요약만 둡니다. 상세 proof나 candidate dump는 `--maintainer-proof`에서만 허용합니다.
 
-`## Next Action Graph`는 구현 runner가 아닙니다. 사용자가 clarification, fixing, re-check, re-run 순서를 이해하도록 run-local Ref로만 가벼운 순서를 적습니다. 예: `Q1 확인 -> G1 수정 -> G2 재확인 -> /tk:gap 재실행`.
+`## Next Action Graph`는 구현 runner가 아닙니다. 사용자가 clarification, fixing, re-check, re-run 순서를 이해하도록 run-local Ref로만 가벼운 순서를 적습니다. 예: `Q1 확인 -> G1 수정 -> G2 재확인 -> /tk:gap --review 재실행`.
 
 ## 금지
 

--- a/commands/launch.md
+++ b/commands/launch.md
@@ -43,7 +43,7 @@ launch = execute sealed workflow + verify gates + abort safely + reflect trace
 2. workflow 파일을 찾습니다.
 3. `tigerkit-launch-workflow` fenced block이 정확히 하나인지 확인합니다.
 4. block body를 LF로 정규화하고 final LF를 하나 보장한 뒤 SHA-256을 계산합니다.
-5. workflow 안의 `workflow_sha256`과 계산값을 비교합니다.
+5. `tigerkit-gap-status`와 `branch-state.json`에 기록된 외부 `workflow_sha256`과 계산값을 비교합니다. `tigerkit-launch-workflow` 내부 자기참조 hash는 사용하지 않습니다.
 6. `status`가 `GAP_READY`인지 확인합니다.
 7. `source_refs`, `requirements`, `tasks`, `verification_gates`, `abort_policy`, `commit_policy`를 확인합니다.
 8. `autopilot_policy.enabled`가 false인데 `--autopilot`이면 abort합니다.
@@ -79,7 +79,7 @@ launch = execute sealed workflow + verify gates + abort safely + reflect trace
 
 각 verification gate는 아래 field를 가져야 합니다.
 
-```yaml
+```text
 id: VG1
 command_id: V1
 purpose: <검증 목적>
@@ -109,8 +109,10 @@ Workflow Hash: <sha256>
 Tasks: <done>/<total>
 Verification Gates: <passed>/<total>
 Commit: <created|skipped_preflight_required|skipped_not_requested>
-Report: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/report.md
-Reflect: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/reflect-report.md
+Report: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+Current: .claude/tigerkit/branches/<branch-key>/launch/current.md
+Reflect: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
+Reflect Current: .claude/tigerkit/branches/<branch-key>/reflect/current.md
 다음 행동: <없음|reflect 제안 검토|commit 승인 필요>
 ```
 
@@ -126,8 +128,10 @@ Abort Code: <CODE>
 원인: <한글 1줄>
 Completed Tasks: <done>/<total>
 Failed Gate: <VG-ID|없음>
-Report: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/report.md
-Reflect: .claude/tigerkit/branches/<branch-key>/launches/<LCH-ID>/reflect-report.md
+Report: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+Current: .claude/tigerkit/branches/<branch-key>/launch/current.md
+Reflect: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
+Reflect Current: .claude/tigerkit/branches/<branch-key>/reflect/current.md
 다음 행동: <human decision|workflow 재생성|scope 조정|검증 실패 수정>
 ```
 

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -54,7 +54,7 @@ Reflect는 current branch scope의 branch-local working memory를 읽습니다.
 ```text
 .claude/tigerkit/branches/<branch-key>/specs/
 .claude/tigerkit/branches/<branch-key>/gap/
-.claude/tigerkit/branches/<branch-key>/launches/
+.claude/tigerkit/branches/<branch-key>/launch/
 .claude/tigerkit/branches/<branch-key>/runs/gap/
 .claude/tigerkit/branches/<branch-key>/branch-state.json
 ```

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -218,7 +218,7 @@
       "id": 10,
       "name": "reflect-after-launch-no-durable-apply-without-approval",
       "prompt": "Evaluate reflect behavior after /tk:launch completes or aborts. Do not write files.",
-      "expected_output": "Should allow /tk:launch to write a generated reflect-report.md trace for /tk:reflect. Should not apply durable CLAUDE.md or .claude/rules changes or create commits unless preflight approval recorded that action. Should classify repo durable insight, skill proposal, TigerKit meta-feedback, verification gap, workflow weakness, and unresolved follow-up separately.",
+      "expected_output": "Should allow /tk:launch to write generated reflect trace artifacts at reflect/<RFL-ID>.md and reflect/current.md for /tk:reflect. Should not apply durable CLAUDE.md or .claude/rules changes or create commits unless preflight approval recorded that action. Should classify repo durable insight, skill proposal, TigerKit meta-feedback, verification gap, workflow weakness, and unresolved follow-up separately.",
       "files": [
         "commands/launch.md",
         "commands/reflect.md",
@@ -253,7 +253,7 @@
       "id": 12,
       "name": "plugin-version-and-command-manifest-v8",
       "prompt": "Evaluate marketplace plugin metadata for TigerKit v8. Do not write files.",
-      "expected_output": "Should set .claude-plugin/plugin.json version to 8.0.0 when origin/main version is 7.4.1 and latest origin/main commit is not a version bump. Should include ./commands/launch.md and preserve existing command entries.",
+      "expected_output": "Should set .claude-plugin/plugin.json version to 8.0.0 when the current origin/main version is a lower patch release produced before the v8 contract correction. Should include ./commands/launch.md and preserve existing command entries.",
       "files": [
         ".claude-plugin/plugin.json",
         "commands/launch.md"


### PR DESCRIPTION
## 요약
- 이슈: Refs #83 — 기존 보강이 v8 계약을 완전히 반영하지 못해 version/schema/storage/eval 표면이 서로 어긋나 있었습니다.
- 수정: plugin version을 8.0.0으로 올리고, 기본 `/tk:gap`을 sealed workflow builder로 정렬했으며, `/tk:gap --review`만 v7 review layout을 쓰도록 분리했습니다. `/tk:launch`/`/tk:reflect` artifact는 `launch/current.md`, `reflect/current.md`, named machine fence, external workflow hash seal 기준으로 맞췄습니다.
- 검증: `claude plugin validate .claude-plugin/plugin.json`, `claude plugin validate .`, `python3 -m json.tool evals/evals.json >/dev/null`, `git diff --check`, v8 contract self-check 통과.

## 변경 사항
- `.claude-plugin/plugin.json` version을 `8.0.0`으로 설정했습니다.
- `commands/gap.md`에서 기본 `/tk:gap` 절차를 `GAP_READY`/`GAP_BLOCKED` sealed workflow 생성 계약으로 재작성했습니다.
- `/tk:gap --review` compatibility 절차는 `runs/gap/<GAP-ID>/report.md` + `run.json` 경로로 보존했습니다.
- `tigerkit-gap-status`, `tigerkit-launch-workflow`, `tigerkit-launch-receipt`, `tigerkit-reflect-report` named machine fence 계약을 문서화했습니다.
- `workflow_sha256`을 workflow block 내부 자기참조가 아니라 `tigerkit-gap-status`/branch state의 외부 seal로 명확히 했습니다.
- launch/reflect 산출물 경로를 `launch/<LCH-ID>.md`, `launch/current.md`, `reflect/<RFL-ID>.md`, `reflect/current.md`로 정리했습니다.
- eval 기대값을 v8.0.0 계약과 current artifact layout에 맞게 갱신했습니다.

## 검증
- [x] `claude plugin validate .claude-plugin/plugin.json` — passed with existing CLAUDE.md root warning
- [x] `claude plugin validate .` — passed
- [x] `python3 -m json.tool evals/evals.json >/dev/null` — passed
- [x] `git diff --check` — passed
- [x] scripted v8 contract self-check — passed
