### PR TITLE
feat: add next command and version bump checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "MTGVim"
   },
   "metadata": {
-    "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, durable reflection, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
+    "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, durable reflection, next-action guidance, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
   },
   "plugins": [
     {
       "name": "tk",
       "source": "./",
-      "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, durable reflection, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
+      "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, durable reflection, next-action guidance, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
-  "description": "sealed GAP workflow, human-approved launch, durable reflection, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "8.0.0",
+  "description": "sealed GAP workflow, human-approved launch, durable reflection, next-action guidance, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
+  "version": "8.0.1",
   "author": {
     "name": "MTGVim"
   },
@@ -9,6 +9,7 @@
     "./commands/gap.md",
     "./commands/launch.md",
     "./commands/reflect.md",
+    "./commands/next.md",
     "./commands/meta-feedback.md",
     "./commands/handoff.md"
   ]

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -134,6 +134,16 @@ proof.json
 
 확인하지 못한 target/producer/plan surface가 사용자 결정을 막으면 proof dump가 아니라 `Clarification Needed` 또는 `Not Accepted Summary`로 표현합니다.
 
+## `/tk:next` artifact policy
+
+`/tk:next`는 v8.0 MVP에서 stdout-only utility입니다. 아래 경로를 생성하지 않습니다.
+
+```text
+.claude/tigerkit/branches/<branch-key>/next/
+```
+
+필요한 경우 latest GAP/launch/reflect/handoff artifact를 읽어 recommendation의 `References`에 path만 기록합니다.
+
 ## Maintainer-only artifacts
 
 `--maintainer-proof`가 명시된 gap run만 기본 artifact에 더해 maintainer-only proof artifact를 생성할 수 있습니다.

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -403,6 +403,27 @@ Abort code 목록:
 - `HYDRATION_CONFLICT`
 - `VERIFICATION_FAILED`
 
+## `/tk:next` Output Contract
+
+- 목적: 현재 TigerKit artifact와 workspace/repo context를 읽고 다음 안전 행동 하나를 추천합니다.
+- MVP는 stdout-only입니다. branch-local artifact를 쓰지 않습니다.
+- `/tk:next`는 `/tk:launch`, commit, PR, source mutation을 실행하지 않습니다.
+- missing artifact는 오류가 아니라 다음 행동 판단 근거입니다.
+
+기본 stdout:
+
+```text
+Next Action: <한글 한 문장 또는 없음>
+Status: recommended | blocked | optional | manual | none
+Recommended Command: </tk:gap ... | /tk:launch | /tk:reflect | /tk:handoff | manual | none>
+Why: <근거 기반 한 줄>
+Blocked By: <none | missing source | human decision | dirty workspace | verification failure | artifact missing | other>
+References:
+- <artifact path or source ref>
+```
+
+`Alternatives`가 필요하면 최대 세 개만 출력합니다. 긴 artifact 본문은 출력하지 않고 path로 참조합니다.
+
 ## `/tk:reflect` Output Contract
 
 - 목적: branch-local working memory와 gap+launch trace에서 durable repo insight만 추출합니다.

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -36,6 +36,7 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 사용자가 고칠 finding과 답할 clarification을 남깁니다. | branch-local |
 | `/tk:launch` | sealed workflow만 실행하고 verification, abort receipt, reflect trace를 남깁니다. | branch-local execution |
 | `/tk:reflect` | gap+launch trace와 branch-local 산출물에서 repo에 남길 insight만 추출하고 반영합니다. | durable insight |
+| `/tk:next` | current state와 TigerKit artifact를 읽어 다음 안전 행동을 추천합니다. 실행·commit·PR은 하지 않습니다. | stdout utility |
 | `/tk:handoff` | 다음 세션이나 다음 작업자가 이어받을 수 있도록 continuation 문서를 작성합니다. | continuation |
 | `/tk:meta-feedback` | 현재 세션에서 드러난 TigerKit command/skill 개선안을 프로젝트 자산 유출 없이 일반화합니다. | generalized feedback |
 
@@ -54,6 +55,8 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 /tk:reflect
 /tk:reflect --dry-run
 /tk:reflect --no-meta-feedback
+/tk:next
+/tk:next "이 브랜치에서 다음 뭐 하지?"
 /tk:handoff 현재 작업 이어받을 수 있게 남겨줘
 /tk:meta-feedback gap 결과가 느리고 BE 오탐이 난 패턴을 일반화해줘
 ```
@@ -148,6 +151,15 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 - apply가 저장을 수행하면 `global-index.json`에 current branch entry가 없을 때 새 entry를 만들 수 있습니다.
 - reflect 처리 직후 `/tk:meta-feedback`을 proposal-only로 함께 제출합니다.
 - `--no-meta-feedback` 또는 `--meta-feedback=false`가 있으면 meta-feedback 제출을 생략합니다.
+
+## `/tk:next`
+
+- `/tk:next`는 GAP → Launch → Reflect pipeline 밖의 utility command입니다.
+- current workspace/repo state, latest GAP workflow/status, latest launch receipt, latest reflect report, latest handoff를 읽고 다음 안전 행동 하나를 추천합니다.
+- source file, durable rule, commit, PR을 만들지 않습니다.
+- MVP 동작은 stdout-only입니다. `.claude/tigerkit/.../next/` artifact를 쓰지 않습니다.
+- output은 `Next Action`, `Status`, `Recommended Command`, `Why`, `Blocked By`, `References` 중심입니다.
+- 추천 상태는 `recommended`, `blocked`, `optional`, `manual`, `none` 중 하나입니다.
 
 ## `/tk:handoff`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,20 +10,21 @@
 ## 검증 및 참조 규칙
 
 - 이 저장소에는 package manager 기반 build/test/lint 설정이 없다.
-- 기능 변경 후에는 `claude plugin validate .claude-plugin/plugin.json`, `claude plugin validate .`, `python3 -m json.tool evals/evals.json >/dev/null`, `git diff --check`를 우선 실행한다.
+- 기능 변경 후에는 `claude plugin validate .claude-plugin/plugin.json`, `claude plugin validate .`, `python3 -m json.tool evals/evals.json >/dev/null`, `python3 scripts/check-plugin-version.py`, `git diff --check`를 우선 실행한다.
 - `evals/evals.json`은 자동 실행 테스트가 아니라 기대 동작 fixture다. eval 검증은 JSON 문법 검증과 수동 기대 동작 검토를 뜻한다.
-- plugin version을 올릴 때는 로컬 파일만 기준으로 계산하지 말고 먼저 `origin/main`의 현재 version을 확인한다.
+- plugin version을 올릴 때는 로컬 파일만 기준으로 계산하지 말고 먼저 `origin/main`의 현재 version을 확인한다. 변경은 `python3 scripts/bump-plugin-version.py <version>` 또는 `--part patch|minor|major`를 사용한다. 이 스크립트는 기본적으로 `origin/main:.claude-plugin/plugin.json`을 기준으로 계산하며, eval에는 특정 version literal을 하드코딩하지 않는다.
 - 사용자 관점 사용법, 산출물 구조, 응답 receipt 세부 규칙은 `.tigerkit/docs/usage.md`, `.tigerkit/docs/artifact-layout.md`, `.tigerkit/docs/output-contract.md`를 기준으로 본다.
 
 ## 핵심 정책
 
 - TigerKit의 목적은 AI-induced source loss를 줄이는 것이다.
-- v8.0 핵심 command flow는 `/tk:gap`, `/tk:launch`, `/tk:reflect`이며 compatibility/secondary command는 `/tk:gap --review`, `/tk:handoff`, `/tk:meta-feedback`다.
+- v8.0 핵심 command flow는 `/tk:gap`, `/tk:launch`, `/tk:reflect`이며 utility/compatibility/secondary command는 `/tk:next`, `/tk:gap --review`, `/tk:handoff`, `/tk:meta-feedback`다.
 - 공개 command surface 변경은 compatibility와 docs/evals 동기화를 함께 검토한다. v8 MVP에서 `/tk:spec`은 공개 command로 노출하지 않는다.
 - Claude Code plugin command는 namespace를 사용하므로 slash invocation은 `/tk:*` 형태다. 자연어 요청은 같은 프로토콜을 따른다.
 - 기본 `/tk:gap`은 사용자 지시, 브레인스토밍, 회의 메모, 결정사항, URL/ticket/docs, legacy branch-local Spec Patch를 source material로 intake하고, source grounding, ambiguity attack, sealed launch workflow 생성을 수행한 뒤 `GAP_READY` 또는 `GAP_BLOCKED`로 끝난다. v7 Contract-based Gap Review는 `/tk:gap --review` compatibility mode로 유지한다.
 - `/tk:launch`는 `GAP_READY` sealed workflow만 실행하며, workflow 밖 scope 확장, missing requirement 임의 해석, verification 없는 success 선언, preflight 승인 없는 commit을 금지한다.
 - `/tk:reflect`는 branch-local working memory에서 repo에 영구 보존할 insight만 추출한다. 기본 동작은 `apply=true`이며, source code는 수정하지 않고 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에 직접 반영한다.
+- `/tk:next`는 현재 TigerKit artifact와 workspace/repo 상태를 읽어 다음 안전 행동을 추천하는 stdout-only utility이며, launch/commit/PR/source mutation을 실행하지 않는다.
 - `/tk:handoff`는 다음 세션이나 다음 작업자가 이어받을 continuation 문서를 작성한다.
 - `/tk:meta-feedback`은 현재 세션 내역에서 TigerKit command/skill 개선안을 일반화해 추출한다.
 - repo convention은 `.claude/rules/**/*.md`를 우선 확인한다.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ claude plugin details tk
 claude plugin install tk@tiger-kit --scope project
 ```
 
-설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:handoff`, `/tk:meta-feedback` 명령을 사용합니다. v8 MVP에서 source intake와 spec normalization은 `/tk:gap`이 담당하므로 `/tk:spec`은 공개 command surface에서 제거되었습니다.
+설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:next`, `/tk:handoff`, `/tk:meta-feedback` 명령을 사용합니다. v8 MVP에서 source intake와 spec normalization은 `/tk:gap`이 담당하므로 `/tk:spec`은 공개 command surface에서 제거되었습니다.
 
 ## Command Surface
 
@@ -40,6 +40,7 @@ claude plugin install tk@tiger-kit --scope project
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 Actionable Finding과 Clarification Needed를 `report.md`와 `run.json`에 남깁니다. | branch-local |
 | `/tk:launch` | sealed workflow만 실행하고 verification, abort receipt, reflect trace를 남깁니다. | branch-local execution |
 | `/tk:reflect` | gap+launch trace와 branch-local working memory에서 repo에 영구 보존할 insight만 rubric으로 선별하고 durable target에 반영한 뒤 기본적으로 meta-feedback을 함께 제출합니다. | durable insight |
+| `/tk:next` | 현재 TigerKit 상태와 workspace/repo context를 읽고 다음 안전 행동 하나를 추천합니다. 실행·commit·PR은 하지 않습니다. | stdout utility |
 | `/tk:handoff` | 다음 세션이나 다음 작업자가 이어받을 continuation 문서와 pending follow-up queue를 작성합니다. | continuation |
 | `/tk:meta-feedback` | 세션 내역에서 TigerKit command/skill 개선안을 일반화해 추출합니다. | generalized feedback |
 
@@ -49,6 +50,7 @@ claude plugin install tk@tiger-kit --scope project
 gap = source intake + source grounding + ambiguity attack + sealed launch workflow 생성
 launch = sealed workflow 실행 + verification + abort/reflect receipt
 reflect = gap+launch trace와 branch-local working memory에서 repo에 영구 보존할 insight만 추출/반영
+next = 현재 상태를 읽고 다음 안전 행동 추천
 handoff = 다음 세션/작업자용 continuation context
 meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
 ```
@@ -56,6 +58,8 @@ meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
 `gap`과 canonical `handoff` 산출물은 `.claude/tigerkit/branches/<branch-key>/` 아래의 branch-local generated working memory입니다. 기존 branch-local Spec Patch가 있으면 `/tk:gap`의 source material로 읽을 수 있지만, v8 MVP는 `/tk:spec` command를 노출하지 않습니다. `/tk:handoff`는 경로 미지정 resume을 위해 `.claude/tigerkit/global-index.json`에 최신 handoff pointer도 기록합니다. repo-wide durable knowledge가 아닙니다.
 
 `/tk:gap` 기본 실행은 `GAP_READY` 또는 `GAP_BLOCKED`로 끝납니다. `GAP_READY`에는 sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
+
+`/tk:next`는 primary execution pipeline 밖의 stdout-only utility입니다. 현재 TigerKit artifact와 workspace 상태를 읽어 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:handoff`, 또는 manual action 중 다음 안전 행동을 추천하지만 실행하지 않습니다.
 
 `reflect`는 durable insight를 Frequency, Cost, Risk, Stability, Coverage rubric으로 평가하고 `apply=true`일 때 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에 직접 반영합니다. 반영할 durable insight가 없으면 파일을 수정하지 않는 것도 정상 성공입니다. reflect 처리 직후 `/tk:meta-feedback`을 proposal-only로 제출하며, `--no-meta-feedback` 또는 `--meta-feedback=false`로 생략할 수 있습니다.
 

--- a/commands/next.md
+++ b/commands/next.md
@@ -1,0 +1,147 @@
+---
+description: 현재 TigerKit 상태를 읽고 다음 안전 행동을 추천합니다.
+argument-hint: "[goal/context?] [--scope current|branch|workspace] [--include-optional] [--no-write]"
+---
+
+이 명령은 TigerKit v8.0 next-action utility contract를 따릅니다. GAP → Launch → Reflect 실행 파이프라인의 일부가 아니며, 작업을 실행하지 않습니다.
+
+사용자에게는 한글로 답합니다. 코드, path, URL, ticket, commit, hash, identifier, error는 원문 그대로 둘 수 있습니다.
+
+목표: `/tk:next`는 현재 workspace/repo 상태와 TigerKit branch-local artifact를 읽어 다음 안전 행동 하나를 추천합니다.
+
+```text
+next = inspect state + classify blockers + recommend one safe next action
+```
+
+## Command surface
+
+- plugin slash invocation은 `/tk:next`입니다.
+- `/tk:next`는 utility command입니다. `/tk:gap → /tk:launch → /tk:reflect` primary pipeline을 대체하거나 자동 실행하지 않습니다.
+- 자연어로 “다음 뭐 하지?”, “next action 정리해줘”처럼 요청해도 이 contract를 따릅니다.
+
+## Inputs to inspect
+
+가능한 범위에서 아래를 읽습니다.
+
+- current worktree/workspace root
+- current branch key 또는 workspace scope key
+- `.claude/tigerkit/branches/<branch-key>/branch-state.json`
+- latest GAP workflow/status: `.claude/tigerkit/branches/<branch-key>/gap/current.md`
+- latest launch receipt: `.claude/tigerkit/branches/<branch-key>/launch/current.md`
+- latest reflect report: `.claude/tigerkit/branches/<branch-key>/reflect/current.md`
+- latest handoff: `.claude/tigerkit/branches/<branch-key>/handoffs/current.md`
+- `.claude/tigerkit/global-index.json` handoff pointer
+- current git status when git is available, using side-effect-minimized inspection such as `git --no-optional-locks status --porcelain=v1 -b`
+- explicit user-provided goal/context in the command arguments
+
+Missing artifacts are not errors. Treat them as evidence that a corresponding next action may be needed.
+
+## Safety rules
+
+`/tk:next` must not:
+
+- execute `/tk:launch`
+- run workflow tasks
+- create commits or PRs
+- mutate source files
+- mutate durable repo rules
+- convert speculative follow-ups into confirmed requirements
+- ask mid-flight execution questions, because it has no flight/execution phase
+
+`/tk:next` may:
+
+- read files under the current workspace root
+- inspect git status when available with side-effect-minimized commands such as `git --no-optional-locks status --porcelain=v1 -b`
+- summarize latest TigerKit artifact states
+- recommend a command or manual action
+- identify blockers
+- optionally write a generated next receipt only if a future contract explicitly enables it
+
+MVP behavior is stdout-only. Do not write `.claude/tigerkit/.../next/` artifacts in v8.0.
+
+## Decision policy
+
+Prefer one primary next action. Classify it as exactly one of:
+
+```text
+recommended
+blocked
+optional
+manual
+none
+```
+
+Recommended priority order:
+
+1. If no GAP workflow exists and the user has a goal/source, recommend `/tk:gap`.
+2. If latest GAP is `GAP_BLOCKED`, recommend resolving the first blocking decision/source.
+3. If latest GAP is `GAP_READY` and no launch receipt exists for the workflow, recommend `/tk:launch` only if preflight risks are acceptable; otherwise recommend preflight/manual check.
+4. If latest launch is `ABORTED`, recommend the abort-specific repair path or `/tk:gap` regeneration.
+5. If latest launch is successful and reflect is missing, recommend `/tk:reflect`.
+6. If reflect produced proposal-only or needs-more-evidence items, recommend reviewing those items.
+7. If handoff has pending backlog relevant to the current user goal, recommend the safest backlog item.
+8. If nothing actionable is found, report `Next Action: 없음` and explain why.
+
+Git dirty state should not automatically block `/tk:next`, but it may change the recommendation from execution to manual review/preflight. Use observational, side-effect-minimized status checks; do not run mutating shell commands.
+
+## Output contract
+
+Default stdout shape:
+
+```text
+Next Action: <한글 한 문장 또는 없음>
+Status: recommended | blocked | optional | manual | none
+Recommended Command: </tk:gap ... | /tk:launch | /tk:reflect | /tk:handoff | manual | none>
+Why: <근거 기반 한 줄>
+Blocked By: <none | missing source | human decision | dirty workspace | verification failure | artifact missing | other>
+References:
+- <artifact path or source ref>
+```
+
+If multiple useful follow-ups exist, include at most three under `Alternatives`.
+
+```text
+Alternatives:
+- <optional action 1>
+- <optional action 2>
+```
+
+Do not output long artifact bodies. Point to paths instead.
+
+## Examples
+
+No workflow exists:
+
+```text
+Next Action: 현재 목표를 `/tk:gap`으로 봉인 가능한 workflow로 정리하세요.
+Status: recommended
+Recommended Command: /tk:gap "<goal/source>"
+Why: branch-local GAP workflow가 아직 없습니다.
+Blocked By: none
+References:
+- .claude/tigerkit/branches/<branch-key>/branch-state.json: missing lastWorkflowPath
+```
+
+Blocked GAP:
+
+```text
+Next Action: Q1의 API owner 결정을 먼저 확인하세요.
+Status: blocked
+Recommended Command: manual
+Why: 최신 GAP이 GAP_BLOCKED이고 launch workflow가 없습니다.
+Blocked By: human decision
+References:
+- .claude/tigerkit/branches/<branch-key>/gap/current.md
+```
+
+Ready to launch:
+
+```text
+Next Action: sealed workflow preflight 후 `/tk:launch`를 실행하세요.
+Status: recommended
+Recommended Command: /tk:launch
+Why: 최신 GAP은 GAP_READY이고 해당 workflow의 launch receipt가 없습니다.
+Blocked By: none
+References:
+- .claude/tigerkit/branches/<branch-key>/gap/current.md
+```

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -35,14 +35,18 @@
       "no Codex CLI adapter in MVP",
       "no runtime parser or binary",
       "autopilot recovery disabled"
+    ],
+    "plugin_version_policy": "Authoritative version is .claude-plugin/plugin.json; evals must not hard-code a concrete version literal.",
+    "utility_commands": [
+      "/tk:next"
     ]
   },
   "evals": [
     {
       "id": 0,
-      "name": "command-surface-v8-gap-launch-reflect-without-spec",
+      "name": "command-surface-v8-gap-launch-reflect-next-without-spec",
       "prompt": "Evaluate TigerKit v8 active command surface. Do not write files.",
-      "expected_output": "Should list /tk:gap, /tk:launch, and /tk:reflect as the primary v8 flow. Should preserve /tk:gap --review, /tk:handoff, and /tk:meta-feedback as compatibility or secondary commands. Should explain that /tk:spec is not exposed in the v8 MVP command surface because source intake is owned by /tk:gap. Should explain that commands/*.md plus .claude-plugin/plugin.json own the /tk:* contracts and that Hermes/Codex/npx-skills command adapters are out of MVP scope with no adapter files shipped.",
+      "expected_output": "Should list /tk:gap, /tk:launch, and /tk:reflect as the primary v8 flow. Should list /tk:next as a stdout-only utility command, not part of the execution pipeline. Should preserve /tk:gap --review, /tk:handoff, and /tk:meta-feedback as compatibility or secondary commands. Should explain that /tk:spec is not exposed in the v8 MVP command surface because source intake is owned by /tk:gap. Should explain that commands/*.md plus .claude-plugin/plugin.json own the /tk:* contracts and that Hermes/Codex/npx-skills command adapters are out of MVP scope with no adapter files shipped.",
       "files": [
         ".claude-plugin/plugin.json",
         "README.md",
@@ -52,6 +56,7 @@
         "Lists /tk:gap",
         "Lists /tk:launch",
         "Lists /tk:reflect",
+        "Lists /tk:next as utility command",
         "Does not expose /tk:spec",
         "Preserves /tk:handoff",
         "Preserves /tk:meta-feedback",
@@ -257,19 +262,52 @@
       "id": 12,
       "name": "plugin-version-and-command-manifest-v8",
       "prompt": "Evaluate marketplace plugin metadata for TigerKit v8. Do not write files.",
-      "expected_output": "Should set .claude-plugin/plugin.json version to 8.0.0 when the current origin/main version is a lower patch release produced before the v8 contract correction. Should include ./commands/launch.md, preserve /tk:gap, /tk:reflect, /tk:handoff, and /tk:meta-feedback command entries, and not include ./commands/spec.md because v8 source intake is owned by /tk:gap.",
+      "expected_output": "Should treat .claude-plugin/plugin.json as the authoritative version source, verify its version is valid semver without hard-coding a concrete version literal in eval expectations, and provide a bump script that defaults to origin/main:.claude-plugin/plugin.json as the baseline so stale local branches do not reuse old versions. Should include ./commands/launch.md and ./commands/next.md, preserve /tk:gap, /tk:reflect, /tk:handoff, and /tk:meta-feedback command entries, and not include ./commands/spec.md because v8 source intake is owned by /tk:gap.",
       "files": [
         ".claude-plugin/plugin.json",
-        "commands/launch.md"
+        "commands/launch.md",
+        "commands/next.md",
+        "scripts/check-plugin-version.py",
+        "scripts/bump-plugin-version.py"
       ],
       "expectations": [
-        "Version is 8.0.0",
+        "Plugin version is valid semver",
+        "No concrete version literal in eval expectations",
         "Includes ./commands/launch.md",
+        "Includes ./commands/next.md",
         "Does not include ./commands/spec.md",
         "Preserves gap command",
         "Preserves reflect command",
         "Preserves handoff command",
-        "Preserves meta-feedback command"
+        "Preserves meta-feedback command",
+        "Version bump script exists",
+        "Version check script exists",
+        "Bump script defaults to origin/main baseline"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "next-command-recommends-without-executing",
+      "prompt": "Evaluate /tk:next when latest GAP is GAP_READY but launch has not run. Do not write files or execute launch.",
+      "expected_output": "Should recommend /tk:launch as the next safe action when latest GAP is GAP_READY and no matching launch receipt exists. Should mark status recommended, include Why, Blocked By, and References. Should not execute launch, create commits, create PRs, or write source files. Should treat /tk:next as stdout-only in v8 MVP.",
+      "files": [
+        "commands/next.md",
+        ".tigerkit/docs/output-contract.md",
+        ".tigerkit/docs/artifact-layout.md",
+        "README.md",
+        ".tigerkit/docs/usage.md"
+      ],
+      "expectations": [
+        "Recommends /tk:launch when GAP_READY has no launch receipt",
+        "Status recommended",
+        "Includes Why",
+        "Includes Blocked By",
+        "Includes References",
+        "Does not execute launch",
+        "Does not create commits or PRs",
+        "Does not mutate source files",
+        "Stdout-only in v8 MVP",
+        "Uses side-effect-minimized git status inspection"
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "type-check": "claude plugin validate .claude-plugin/plugin.json",
     "lint": "claude plugin validate .",
     "format:check": "git diff --check",
-    "test": "python3 -m json.tool evals/evals.json >/dev/null",
-    "validate": "bun run type-check && bun run lint && bun run format:check && bun run test"
+    "test": "python3 -m json.tool evals/evals.json >/dev/null && python3 -m json.tool .claude-plugin/plugin.json >/dev/null && python3 -m json.tool .claude-plugin/marketplace.json >/dev/null && python3 scripts/check-plugin-version.py",
+    "bump:plugin": "python3 scripts/bump-plugin-version.py",
+    "validate": "claude plugin validate .claude-plugin/plugin.json && claude plugin validate . && git diff --check && python3 -m json.tool evals/evals.json >/dev/null && python3 -m json.tool .claude-plugin/plugin.json >/dev/null && python3 -m json.tool .claude-plugin/marketplace.json >/dev/null && python3 scripts/check-plugin-version.py"
   }
 }

--- a/scripts/bump-plugin-version.py
+++ b/scripts/bump-plugin-version.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Bump .claude-plugin/plugin.json version from an origin/main baseline.
+
+Usage:
+  python3 scripts/bump-plugin-version.py --part patch
+  python3 scripts/bump-plugin-version.py 8.0.1
+  python3 scripts/bump-plugin-version.py --dry-run --part minor
+
+By default, calculated bumps use origin/main:.claude-plugin/plugin.json as the
+baseline so stale local branches do not accidentally reuse an old version. Use
+--base local only for offline/manual repair workflows.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_PATH = ROOT / ".claude-plugin" / "plugin.json"
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def parse_version(value: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.match(value)
+    if not match:
+        raise SystemExit(f"Expected plain semver MAJOR.MINOR.PATCH, got {value!r}")
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def load_local_plugin() -> dict:
+    return json.loads(PLUGIN_PATH.read_text())
+
+
+def load_origin_plugin() -> dict:
+    result = subprocess.run(
+        ["git", "show", "origin/main:.claude-plugin/plugin.json"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "Could not read origin/main:.claude-plugin/plugin.json. "
+            "Run `git fetch origin` first or pass --base local for an explicit offline bump.\n"
+            + result.stderr.strip()
+        )
+    return json.loads(result.stdout)
+
+
+def bump_version(base: tuple[int, int, int], part: str) -> tuple[int, int, int]:
+    major, minor, patch = base
+    if part == "major":
+        return major + 1, 0, 0
+    if part == "minor":
+        return major, minor + 1, 0
+    return major, minor, patch + 1
+
+
+def version_text(version: tuple[int, int, int]) -> str:
+    return f"{version[0]}.{version[1]}.{version[2]}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", nargs="?", help="Explicit version, e.g. 8.0.1")
+    parser.add_argument("--part", choices=["major", "minor", "patch"], default="patch")
+    parser.add_argument("--base", choices=["origin-main", "local"], default="origin-main")
+    parser.add_argument("--dry-run", action="store_true", help="Print the version change without writing plugin.json")
+    args = parser.parse_args()
+
+    local_plugin = load_local_plugin()
+    local_raw = local_plugin.get("version")
+    if not isinstance(local_raw, str):
+        raise SystemExit("plugin.json is missing string version")
+    local_version = parse_version(local_raw)
+
+    if args.base == "origin-main":
+        origin_raw = load_origin_plugin().get("version")
+        if not isinstance(origin_raw, str):
+            raise SystemExit("origin/main plugin.json is missing string version")
+        base_raw = origin_raw
+        base_version = parse_version(origin_raw)
+    else:
+        base_raw = local_raw
+        base_version = local_version
+
+    if args.version:
+        new_raw = args.version
+        new_version = parse_version(new_raw)
+    else:
+        new_version = bump_version(base_version, args.part)
+        new_raw = version_text(new_version)
+
+    if args.base == "origin-main" and new_version <= base_version:
+        raise SystemExit(f"New version {new_raw} must be greater than origin/main version {base_raw}")
+
+    if args.dry_run:
+        print(f"base({args.base}) {base_raw}; local {local_raw}; new {new_raw}; dry-run")
+        return 0
+
+    local_plugin["version"] = new_raw
+    PLUGIN_PATH.write_text(json.dumps(local_plugin, ensure_ascii=False, indent=2) + "\n")
+    print(f"base({args.base}) {base_raw}; local {local_raw} -> {new_raw}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-plugin-version.py
+++ b/scripts/check-plugin-version.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Validate TigerKit plugin version and command manifest invariants.
+
+The authoritative plugin version lives in .claude-plugin/plugin.json.
+This script intentionally avoids hard-coded release numbers so patch/minor
+bumps do not require eval rewrites.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_PATH = ROOT / ".claude-plugin" / "plugin.json"
+MARKETPLACE_PATH = ROOT / ".claude-plugin" / "marketplace.json"
+EVALS_PATH = ROOT / "evals" / "evals.json"
+SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:[-+][0-9A-Za-z.-]+)?$")
+
+
+def load_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # pragma: no cover - CLI diagnostic
+        raise SystemExit(f"Invalid JSON: {path}: {exc}") from exc
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"plugin version check failed: {message}")
+
+
+def main() -> int:
+    plugin = load_json(PLUGIN_PATH)
+    marketplace = load_json(MARKETPLACE_PATH)
+    evals = load_json(EVALS_PATH)
+
+    version = plugin.get("version")
+    if not isinstance(version, str) or not SEMVER_RE.match(version):
+        fail(f".claude-plugin/plugin.json version must be semver, got {version!r}")
+
+    commands = plugin.get("commands")
+    if not isinstance(commands, list) or not commands:
+        fail("plugin commands must be a non-empty list")
+
+    seen: set[str] = set()
+    for command in commands:
+        if not isinstance(command, str):
+            fail(f"command entry must be a string, got {command!r}")
+        if command in seen:
+            fail(f"duplicate command entry: {command}")
+        seen.add(command)
+        command_path = (ROOT / command).resolve()
+        if ROOT not in command_path.parents:
+            fail(f"command path escapes repo: {command}")
+        if not command_path.exists():
+            fail(f"command path does not exist: {command}")
+
+    plugin_name = plugin.get("name")
+    marketplace_plugins = marketplace.get("plugins")
+    if not isinstance(marketplace_plugins, list) or not marketplace_plugins:
+        fail("marketplace plugins must be a non-empty list")
+    if not any(item.get("name") == plugin_name and item.get("source") == "./" for item in marketplace_plugins if isinstance(item, dict)):
+        fail(f"marketplace.json must expose plugin {plugin_name!r} with source './'")
+
+    eval_text = EVALS_PATH.read_text()
+    if re.search(r"Version is \d+\.\d+\.\d+", eval_text):
+        fail(
+            "evals/evals.json hard-codes a plugin version; "
+            "assert version format/policy instead so future bumps work"
+        )
+    if "plugin-version-and-command-manifest" not in eval_text:
+        fail("evals/evals.json must include a plugin version/manifest invariant eval")
+
+    print(f"plugin version ok: {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 요약
- 이슈: #91 plugin version bump가 eval/검증에서 하드코딩에 막히고, 다음 안전 행동을 추천하는 `/tk:next` utility command가 필요했습니다.
- 수정: plugin version을 8.0.1로 올리고 origin/main 기준 bump/check 스크립트를 추가했으며, `/tk:next` command와 README/docs/evals/manifest를 연결했습니다.
- 검증: Claude plugin validation, marketplace validation, JSON syntax, version check, diff check, package validate script를 통과했습니다.

Closes #91

## 변경 사항
- `.claude-plugin/plugin.json` version `8.0.1`
- `./commands/next.md` command 등록
- `/tk:next` command contract 추가
  - stdout-only utility
  - `/tk:launch`, commit, PR, source mutation 금지
  - latest GAP/launch/reflect/handoff와 workspace state를 읽고 next safe action 추천
- `scripts/bump-plugin-version.py` 추가
  - 기본적으로 `origin/main:.claude-plugin/plugin.json` 기준으로 bump
  - stale local branch에서 잘못된 patch bump가 나는 문제 방지
  - `--dry-run`, `--base local` 지원
- `scripts/check-plugin-version.py` 추가
  - semver 검증
  - command manifest path 존재 확인
  - marketplace plugin exposure 확인
  - eval의 concrete version literal 하드코딩 방지
- `package.json` validate에서 `bun run`/`npm run` 같은 package-manager 하드코딩 제거
  - 사용자는 `yarn validate`로 호출해도 내부는 direct command chain만 실행
- eval에서 `Version is 8.0.0` 같은 change-detector expectation 제거

## 검증
```text
python3 scripts/bump-plugin-version.py --dry-run --part patch
python3 scripts/bump-plugin-version.py --dry-run 8.0.1
claude plugin validate .claude-plugin/plugin.json
claude plugin validate .
python3 -m json.tool package.json >/dev/null
python3 -m json.tool evals/evals.json >/dev/null
python3 -m json.tool .claude-plugin/plugin.json >/dev/null
python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
python3 scripts/check-plugin-version.py
git diff --check
npm run validate
```

## 참고
- 검증 환경에는 `yarn`이 없어서 `yarn validate`는 직접 실행하지 못했습니다. 대신 package script 내부에서 package-manager recursion을 제거해 `yarn validate`로 호출해도 bun/npm을 찾지 않도록 했습니다.
- Claude plugin validation의 root `CLAUDE.md` warning은 기존 구조 경고이며 이번 변경으로 새로 생긴 실패가 아닙니다.
