### PR TITLE
feat: support workspace fallback mode

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "sealed GAP workflow, human-approved launch, durable reflection, next-action guidance, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "8.0.1",
+  "version": "8.1.0",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -55,6 +55,16 @@ TigerKit은 branch-local working memory와 durable insight를 분리합니다.
     gap-baselines.json
 ```
 
+## Workspace fallback storage
+
+Git이 없는 plain workspace도 같은 generated state root를 사용합니다. 이때 `<branch-key>` 자리에 workspace fallback `scope_key`를 사용합니다.
+
+```text
+.claude/tigerkit/branches/workspace-<basename-slug>--<hash>/
+```
+
+MVP에서는 path compatibility를 위해 `branches/` 아래에 저장하지만 receipt에는 `Scope Kind: workspace`를 반드시 표시합니다.
+
 ## 파일 책임
 
 | 파일 | 역할 | 저장 성격 |

--- a/.tigerkit/docs/branch-local-contract.md
+++ b/.tigerkit/docs/branch-local-contract.md
@@ -1,6 +1,6 @@
 # TigerKit branch-local storage contract
 
-이 문서는 TigerKit v8.0 branch-local working memory의 저장 위치, branch key, index, write safety, gap/launch/handoff/reflect 경계를 설명합니다. 산출물 전체 구조는 `.tigerkit/docs/artifact-layout.md`, command stdout 계약은 `.tigerkit/docs/output-contract.md`를 기준으로 봅니다.
+이 문서는 TigerKit v8.0 branch/workspace-local working memory의 저장 위치, scope key, index, write safety, gap/launch/handoff/reflect 경계를 설명합니다. 산출물 전체 구조는 `.tigerkit/docs/artifact-layout.md`, command stdout 계약은 `.tigerkit/docs/output-contract.md`를 기준으로 봅니다.
 
 ## 기본 저장 위치
 
@@ -52,11 +52,11 @@ Handoff canonical 위치:
 - `/tmp`
 - current worktree root 밖 경로
 
-`.claude/tigerkit/`은 generated branch-local working memory이며 repo-wide durable knowledge가 아닙니다.
+`.claude/tigerkit/`은 generated branch/workspace-local working memory이며 repo-wide durable knowledge가 아닙니다.
 
-## Branch key
+## Scope key
 
-브랜치명을 디렉터리명으로 직접 쓰지 않습니다.
+브랜치명이나 workspace path를 디렉터리명으로 직접 쓰지 않습니다.
 
 Normal branch:
 
@@ -75,6 +75,15 @@ branchKey = detached-<shortHeadSha7>--<sha256(worktreeRoot).slice(0, 6)>
 ```
 
 Detached 상태면 summary에 branch scope가 detached임을 알립니다.
+
+Plain workspace fallback:
+
+```text
+scopeKind = workspace
+scopeKey = workspace-<basename-slug>--<sha256(absWorkspaceRoot).slice(0, 8)>
+```
+
+`git rev-parse --show-toplevel`이 실패하면 current working directory를 `workspaceRoot`로 사용합니다. basename slug가 비거나 안전하지 않으면 `workspace--<hash>`를 씁니다. stdout과 machine-readable receipt에는 `Scope Kind: workspace`를 함께 표시합니다.
 
 ## Index files
 
@@ -112,7 +121,7 @@ Atomic write 대상:
 
 ## Path safety
 
-TigerKit generated artifact 경로는 normalize 후 current worktree root 내부이면서 `.claude/tigerkit/branches/<branch-key>/` 아래여야 합니다. worktree root 밖이면 중단하고 아래 메시지를 사용합니다.
+TigerKit generated artifact 경로는 normalize 후 current worktree/workspace root 내부이면서 `.claude/tigerkit/branches/<scope-key>/` 아래여야 합니다. worktree root 밖이면 중단하고 아래 메시지를 사용합니다.
 
 ```text
 Tiger Kit does not read or write files outside the current worktree by default.
@@ -126,7 +135,7 @@ Tiger Kit does not read or write files outside the current worktree by default.
 
 상세 artifact layout은 `.tigerkit/docs/artifact-layout.md`를 기준으로 합니다. 상세 stdout/report 계약은 `.tigerkit/docs/output-contract.md`를 기준으로 합니다.
 
-`.claude/tigerkit/`은 generated branch-local working memory이며 repo-wide durable knowledge가 아닙니다.
+`.claude/tigerkit/`은 generated branch/workspace-local working memory이며 repo-wide durable knowledge가 아닙니다.
 
 ## `/tk:gap` sealed workflow storage
 

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -13,7 +13,7 @@ stdout is a receipt. Full gap bodies are saved as branch-local artifacts unless 
 1. outcome
 2. branch scope
 3. artifact paths when files are written
-4. counts, risks, next action
+4. counts, risks, capability/skip reason, next action
 
 상세 본문은 파일에 저장하고, 각 command가 지원하는 explicit print option을 지정한 경우에만 stdout에 함께 출력합니다. v8 MVP 공개 command surface에서는 `/tk:gap`의 `--print-report`가 이에 해당합니다.
 
@@ -82,6 +82,16 @@ missing_sources: []
 
 ```tigerkit-launch-workflow
 version: 1
+workspace_context:
+  root: <absolute path>
+  scope_kind: git_branch | git_detached | git_no_remote | workspace
+  scope_key: <stable key>
+  git:
+    available: true | false
+    commit_available: true | false
+  github:
+    remote_available: true | false
+    issue_pr_available: true | false
 workflow_id: WF-YYYYMMDD-HHmmss-RAND
 created_at: <ISO-8601>
 source_refs: []
@@ -108,8 +118,10 @@ autopilot_policy:
   max_task_retries: 0
   forbidden: []
 commit_policy:
-  mode: preflight_decision_required
+  mode: preflight_decision_required | skip | commit_on_success
   allowed: false
+  commit_available: true | false
+  skip_reason: null | not_git_repo | no_commit_requested | github_unavailable | readonly_workspace
 reflect_policy:
   mode: generated_report_only
   durable_apply_requires_preflight_approval: true
@@ -349,6 +361,7 @@ workflow_sha256: <sha256>
 status: SUCCESS_NO_COMMIT | SUCCESS_COMMITTED | ABORTED | FAILED_PREFLIGHT
 abort_code: null
 commit_created: false
+commit_status: created | skipped_preflight_required | skipped_not_requested | skipped_not_git_repo | skipped_no_github_remote | skipped_readonly_workspace | skipped_commit_policy_skip
 reflect_report_path: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
 reflect_current_path: .claude/tigerkit/branches/<branch-key>/reflect/current.md
 ```
@@ -363,7 +376,7 @@ Workflow Hash: <sha256>
 결과: SUCCESS
 Tasks: <done>/<total>
 Verification Gates: <passed>/<total>
-Commit: <created|skipped_preflight_required|skipped_not_requested>
+Commit: <created|skipped_preflight_required|skipped_not_requested|skipped_not_git_repo|skipped_no_github_remote|skipped_readonly_workspace|skipped_commit_policy_skip>
 Report: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
 Current: .claude/tigerkit/branches/<branch-key>/launch/current.md
 Reflect: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
@@ -402,6 +415,10 @@ Abort code 목록:
 - `OUT_OF_SCOPE_DIFF`
 - `HYDRATION_CONFLICT`
 - `VERIFICATION_FAILED`
+- `ARTIFACT_ROOT_UNWRITABLE`
+- `COMMIT_REQUIRED_UNAVAILABLE`
+- `GITHUB_REQUIRED_UNAVAILABLE`
+- `VERIFICATION_UNAVAILABLE`
 
 ## `/tk:next` Output Contract
 
@@ -456,6 +473,7 @@ mode: generated_report_only | durable_apply
 applied: []
 skipped: []
 proposal_only: []
+user_memory_candidates: []
 ```
 
 기본 stdout:
@@ -477,6 +495,10 @@ Apply: true
 
 Needs more evidence:
 - <확인 필요 항목 또는 None>
+
+User-level Memory Candidates:
+- <candidate or None>
+  Auto-applied: false
 
 Meta Feedback:
 - submitted
@@ -501,6 +523,10 @@ Apply: false
 
 Needs more evidence:
 - <확인 필요 항목 또는 None>
+
+User-level Memory Candidates:
+- <candidate or None>
+  Auto-applied: false
 
 Meta Feedback:
 - submitted
@@ -527,6 +553,10 @@ Apply: true
 
 Needs more evidence:
 - <확인 필요 항목 또는 None>
+
+User-level Memory Candidates:
+- <candidate or None>
+  Auto-applied: false
 
 Meta Feedback:
 - submitted

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -14,15 +14,33 @@
 TigerKit = branch-scoped source intake + sealed gap workflow + human-approved launch + durable reflection + continuation handoff + generalized meta-feedback
 ```
 
-TigerKit은 branch-local working memory와 durable repo insight를 분리합니다.
+TigerKit은 branch/workspace-local working memory와 durable repo insight를 분리합니다.
 
 - 사용자 입력, 문서, 스크린샷, 회의 메모, 이전 계획은 source material이며 그 자체로 authority가 아닙니다.
-- `gap` 산출물은 현재 브랜치의 working memory입니다.
+- `gap` 산출물은 현재 branch 또는 plain workspace scope의 working memory입니다.
 - 기존 branch-local Spec Patch가 있으면 `/tk:gap`이 source material로 읽을 수 있지만, v8 MVP는 `/tk:spec` command를 노출하지 않습니다.
 - 해당 산출물은 repo-wide durable knowledge가 아닙니다.
 - repo에 영구적으로 남길 insight는 `reflect`만 추출하고 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에 반영합니다.
 - 다음 세션을 위한 사람이 읽는 continuation과 pending follow-up queue는 `handoff`가 담당합니다.
 - TigerKit command/skill 자체 개선 피드백은 `meta-feedback`이 담당합니다.
+
+## Workspace fallback mode
+
+TigerKit은 GitHub repo 전용 도구가 아닙니다. 아래 context에서도 `/tk:gap`, `/tk:launch`, `/tk:reflect`가 동작해야 합니다.
+
+- GitHub remote가 없는 git repo
+- git 자체가 없는 plain workspace
+- notes/docs/operations runbook folder
+- commit이나 PR을 원하지 않는 작업
+- 코드 수정이 아닌 문서 생성, research, checklist, data cleanup 작업
+
+원칙:
+
+- git/GitHub 부재는 기본적으로 launch blocker가 아닙니다.
+- commit/PR은 workflow가 명시적으로 요구할 때만 필요합니다.
+- non-git workspace에서는 `scope_kind=workspace`와 안정적인 `scope_key`를 기록합니다.
+- 검증은 test command뿐 아니라 `file_exists`, `file_contains`, `artifact_written`, `schema_valid`, `manual_review_required`, `receipt_only` 같은 non-code gate도 허용합니다.
+- reflect는 repo durable target이 없으면 generated report와 user-level memory candidate/proposal 중심으로 fallback합니다.
 
 ## Command Surface
 
@@ -34,7 +52,7 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 | --- | --- | --- |
 | `/tk:gap` | 사용자 입력, 문서, 스크린샷, 회의 메모, 기존 branch-local Spec Patch를 source material로 intake하고, source grounding, ambiguity attack, sealed launch workflow 생성을 수행한 뒤 `GAP_READY` 또는 `GAP_BLOCKED`로 끝납니다. | branch-local |
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 사용자가 고칠 finding과 답할 clarification을 남깁니다. | branch-local |
-| `/tk:launch` | sealed workflow만 실행하고 verification, abort receipt, reflect trace를 남깁니다. | branch-local execution |
+| `/tk:launch` | sealed workflow만 실행하고 verification, abort receipt, reflect trace를 남깁니다. git/GitHub/commit은 capability로 기록하고 필요 없으면 skip reason으로 성공할 수 있습니다. | branch/workspace-local execution |
 | `/tk:reflect` | gap+launch trace와 branch-local 산출물에서 repo에 남길 insight만 추출하고 반영합니다. | durable insight |
 | `/tk:next` | current state와 TigerKit artifact를 읽어 다음 안전 행동을 추천합니다. 실행·commit·PR은 하지 않습니다. | stdout utility |
 | `/tk:handoff` | 다음 세션이나 다음 작업자가 이어받을 수 있도록 continuation 문서를 작성합니다. | continuation |
@@ -114,6 +132,9 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 ### `/tk:launch`
 
 - `/tk:launch`는 sealed workflow만 실행합니다.
+- missing git/GitHub는 workflow가 commit/PR을 요구하지 않는 한 abort 사유가 아닙니다.
+- non-git workspace 성공 시 commit은 `skipped_not_git_repo`로 기록할 수 있습니다.
+- git diff가 없으면 file manifest snapshot 또는 receipt-only diff scope를 workflow policy에 따라 사용합니다.
 - workflow 밖 scope 확장, missing requirement 임의 해석, public API/DB/product behavior 재정의, verification 없는 success 선언, out-of-scope diff commit을 금지합니다.
 - mid-flight 질문을 하지 않습니다. 새 사용자 결정이 필요하면 `HUMAN_DECISION_REQUIRED`로 abort합니다.
 - `/tk:launch --autopilot`은 Phase 1에서 recovery를 수행하지 않고 `AUTOPILOT_DISABLED` 또는 `AUTOPILOT_NOT_IMPLEMENTED_IN_PHASE1`로 abort합니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@
 - 공개 command surface 변경은 compatibility와 docs/evals 동기화를 함께 검토한다. v8 MVP에서 `/tk:spec`은 공개 command로 노출하지 않는다.
 - Claude Code plugin command는 namespace를 사용하므로 slash invocation은 `/tk:*` 형태다. 자연어 요청은 같은 프로토콜을 따른다.
 - 기본 `/tk:gap`은 사용자 지시, 브레인스토밍, 회의 메모, 결정사항, URL/ticket/docs, legacy branch-local Spec Patch를 source material로 intake하고, source grounding, ambiguity attack, sealed launch workflow 생성을 수행한 뒤 `GAP_READY` 또는 `GAP_BLOCKED`로 끝난다. v7 Contract-based Gap Review는 `/tk:gap --review` compatibility mode로 유지한다.
-- `/tk:launch`는 `GAP_READY` sealed workflow만 실행하며, workflow 밖 scope 확장, missing requirement 임의 해석, verification 없는 success 선언, preflight 승인 없는 commit을 금지한다.
-- `/tk:reflect`는 branch-local working memory에서 repo에 영구 보존할 insight만 추출한다. 기본 동작은 `apply=true`이며, source code는 수정하지 않고 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에 직접 반영한다.
+- `/tk:launch`는 `GAP_READY` sealed workflow만 실행하며, workflow 밖 scope 확장, missing requirement 임의 해석, verification 없는 success 선언, preflight 승인 없는 commit을 금지한다. git/GitHub 부재는 workflow가 commit/PR을 요구하지 않는 한 abort 사유가 아니며 명시 skip reason으로 기록한다.
+- `/tk:reflect`는 branch/workspace-local working memory에서 repo에 영구 보존할 insight만 추출한다. 기본 동작은 `apply=true`이며, source code는 수정하지 않고 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에 직접 반영한다.
 - `/tk:next`는 현재 TigerKit artifact와 workspace/repo 상태를 읽어 다음 안전 행동을 추천하는 stdout-only utility이며, launch/commit/PR/source mutation을 실행하지 않는다.
 - `/tk:handoff`는 다음 세션이나 다음 작업자가 이어받을 continuation 문서를 작성한다.
 - `/tk:meta-feedback`은 현재 세션 내역에서 TigerKit command/skill 개선안을 일반화해 추출한다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TigerKit
 
-TigerKit(`tk`, plugin namespace `/tk:*`)은 sealed GAP → Launch → Reflect 흐름과 continuation handoff, generalized meta-feedback으로 AI-induced source loss를 줄입니다.
+TigerKit(`tk`, plugin namespace `/tk:*`)은 sealed GAP → Launch → Reflect 흐름과 continuation handoff, generalized meta-feedback으로 AI-induced source loss를 줄입니다. GitHub PR/commit은 선택 capability이며, plain workspace에서도 workflow 작성·실행·회고가 가능해야 합니다.
 
 공개 실행 표면은 Claude Code plugin command입니다. 별도 repo-local skill 파일 없이 `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다.
 
@@ -57,7 +57,9 @@ meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
 
 `gap`과 canonical `handoff` 산출물은 `.claude/tigerkit/branches/<branch-key>/` 아래의 branch-local generated working memory입니다. 기존 branch-local Spec Patch가 있으면 `/tk:gap`의 source material로 읽을 수 있지만, v8 MVP는 `/tk:spec` command를 노출하지 않습니다. `/tk:handoff`는 경로 미지정 resume을 위해 `.claude/tigerkit/global-index.json`에 최신 handoff pointer도 기록합니다. repo-wide durable knowledge가 아닙니다.
 
-`/tk:gap` 기본 실행은 `GAP_READY` 또는 `GAP_BLOCKED`로 끝납니다. `GAP_READY`에는 sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
+`/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY` 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
+
+GitHub remote, git branch, commit 가능 여부는 launch preflight capability로 기록하며 prerequisite가 아닙니다. commit/PR이 불가능해도 workflow가 commit/PR을 요구하지 않으면 `/tk:launch`는 `Commit: skipped_not_git_repo` 같은 명시 skip reason으로 성공할 수 있습니다.
 
 `/tk:next`는 primary execution pipeline 밖의 stdout-only utility입니다. 현재 TigerKit artifact와 workspace 상태를 읽어 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:handoff`, 또는 manual action 중 다음 안전 행동을 추천하지만 실행하지 않습니다.
 

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -54,6 +54,45 @@ TigerKit 자체 성능 개선, baseline, heuristic proof, performance proof, fal
 
 Workflow hash는 fenced block body raw UTF-8 bytes를 LF로 정규화하고 final LF를 하나 보장한 뒤 SHA-256으로 계산합니다. opening/closing fence line은 hash에서 제외하고 YAML key sort나 normalize를 하지 않습니다.
 
+## Workspace context and fallback mode
+
+`/tk:gap`은 git/GitHub repository를 prerequisite로 요구하지 않습니다. preflight/source grounding 중 아래 capability를 normalized context로 기록합니다.
+
+```yaml
+workspace_context:
+  root: <absolute path>
+  scope_kind: git_branch | git_detached | git_no_remote | workspace
+  scope_key: <stable key>
+  git:
+    available: true | false
+    repo_root: <path|null>
+    branch: <name|null>
+    detached_head: true | false
+    dirty_state_available: true | false
+    commit_available: true | false
+  github:
+    remote_available: true | false
+    owner_repo: <owner/repo|null>
+    issue_pr_available: true | false
+  artifact_root:
+    path: .claude/tigerkit/branches/<scope-key>
+    writable: true | false
+```
+
+If git is unavailable, use `scope_kind=workspace` and compute `scope_key = workspace-<basename-slug>--<sha256(absWorkspaceRoot).slice(0, 8)>`. Missing git or GitHub is not a blocker unless the requested workflow explicitly requires commit or PR behavior.
+
+Sealed workflow tasks are not limited to code changes. Allowed task types include:
+
+```text
+code_change | docs_change | research | file_generation | data_cleanup | ops_runbook | communication_draft | analysis | manual_receipt
+```
+
+Verification gates may be shell-based or artifact-based:
+
+```text
+shell_command | file_exists | file_contains | artifact_written | link_checked | schema_valid | manual_review_required | receipt_only
+```
+
 ## `/tk:gap --review` 핵심 원칙
 
 - Product/Design Spec 기반 inspection입니다.

--- a/commands/launch.md
+++ b/commands/launch.md
@@ -39,7 +39,7 @@ launch = execute sealed workflow + verify gates + abort safely + reflect trace
 
 ## Preflight
 
-1. current worktree root와 branch key를 계산합니다.
+1. current worktree/workspace root와 scope key를 계산합니다. git이 없으면 `scope_kind=workspace` fallback을 사용합니다.
 2. workflow 파일을 찾습니다.
 3. `tigerkit-launch-workflow` fenced block이 정확히 하나인지 확인합니다.
 4. block body를 LF로 정규화하고 final LF를 하나 보장한 뒤 SHA-256을 계산합니다.
@@ -48,7 +48,34 @@ launch = execute sealed workflow + verify gates + abort safely + reflect trace
 7. `source_refs`, `requirements`, `tasks`, `verification_gates`, `abort_policy`, `commit_policy`를 확인합니다.
 8. `autopilot_policy.enabled`가 false인데 `--autopilot`이면 abort합니다.
 9. worktree 선택이 명시되어 있으면 workflow의 worktree policy와 충돌하지 않는지 확인합니다.
-10. commit 가능 여부는 `commit_policy`와 preflight approval evidence로만 판단합니다.
+10. commit 가능 여부는 `commit_policy`, workspace capability, preflight approval evidence로만 판단합니다. git/GitHub가 없어도 workflow가 commit/PR을 요구하지 않으면 launch를 계속할 수 있습니다.
+
+## Commit and VCS fallback
+
+Missing git or GitHub is not an abort by itself. It becomes an abort only when the sealed workflow requires commit/PR behavior.
+
+Allowed commit receipt values:
+
+```text
+created
+skipped_preflight_required
+skipped_not_requested
+skipped_not_git_repo
+skipped_no_github_remote
+skipped_readonly_workspace
+skipped_commit_policy_skip
+```
+
+If git diff is unavailable, use the workflow diff policy:
+
+```yaml
+diff_scope:
+  mode: git_diff | file_manifest_snapshot | receipt_only
+  before_files: <manifest path|null>
+  after_files: <manifest path|null>
+  changed_files: <list|unknown>
+  diff_lines: <number|unknown>
+```
 
 ## Abort codes
 
@@ -64,6 +91,10 @@ launch = execute sealed workflow + verify gates + abort safely + reflect trace
 | `OUT_OF_SCOPE_DIFF` | workflow 밖 파일·동작 변경 필요 또는 발생 | 변경 중단 후 abort |
 | `HYDRATION_CONFLICT` | tracked file symlink 등 hydration 충돌 | hydration 중단 후 abort |
 | `VERIFICATION_FAILED` | verification gate 실패 | 실패 evidence와 함께 abort |
+| `ARTIFACT_ROOT_UNWRITABLE` | branch/workspace-local artifact root에 쓸 수 없음 | 실행 전 abort |
+| `COMMIT_REQUIRED_UNAVAILABLE` | workflow가 commit을 요구하지만 git/commit capability가 없음 | 실행 전 abort |
+| `GITHUB_REQUIRED_UNAVAILABLE` | workflow가 PR/GitHub 작업을 요구하지만 GitHub capability가 없음 | 실행 전 abort |
+| `VERIFICATION_UNAVAILABLE` | required verification을 수행할 방법이 없음 | 실행 전 abort |
 
 ## Execution rules
 
@@ -73,7 +104,7 @@ launch = execute sealed workflow + verify gates + abort safely + reflect trace
 - mid-flight 질문을 하지 않습니다. 결정이 필요하면 `HUMAN_DECISION_REQUIRED`로 abort합니다.
 - out-of-scope diff를 만들지 않습니다. 발견하면 `OUT_OF_SCOPE_DIFF`로 abort합니다.
 - verification 없이 success를 선언하지 않습니다.
-- commit은 `commit_policy.mode=commit_on_success`만으로 수행하지 않습니다. preflight receipt에 `user_preapproved_commit=true`와 `approval_source_ref`가 있어야 합니다.
+- commit은 `commit_policy.mode=commit_on_success`만으로 수행하지 않습니다. commit unavailable 상태라도 commit이 required가 아니면 skip reason을 기록하고 success가 가능합니다. preflight receipt에 `user_preapproved_commit=true`와 `approval_source_ref`가 있어야 합니다.
 
 ## Verification gates
 
@@ -108,7 +139,7 @@ Workflow Hash: <sha256>
 결과: SUCCESS
 Tasks: <done>/<total>
 Verification Gates: <passed>/<total>
-Commit: <created|skipped_preflight_required|skipped_not_requested>
+Commit: <created|skipped_preflight_required|skipped_not_requested|skipped_not_git_repo|skipped_no_github_remote|skipped_readonly_workspace|skipped_commit_policy_skip>
 Report: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
 Current: .claude/tigerkit/branches/<branch-key>/launch/current.md
 Reflect: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md
@@ -145,3 +176,4 @@ Reflect Current: .claude/tigerkit/branches/<branch-key>/reflect/current.md
 - mid-flight 사용자 질문
 - Phase 1 autopilot recovery 수행
 - preflight 승인 없는 commit
+- commit/PR이 optional인 workflow를 git/GitHub 부재만으로 abort

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -10,7 +10,7 @@ argument-hint: "[scope] [--dry-run] [--apply=true|false] [--target <CLAUDE.md|.c
 목표: `/tk:reflect`는 Gap workflow, Launch trace, Gap이 already-grounded source로 채택한 legacy Spec Patch reference에서 repo-wide 가치가 있는 durable insight만 추출해 적절한 durable surface에 직접 반영합니다.
 
 ```text
-reflect = branch-local gap+launch working memory -> CLAUDE.md/.claude/rules durable reflection
+reflect = branch/workspace-local gap+launch working memory -> safest available durable/proposal target
 ```
 
 ## Command surface
@@ -22,10 +22,10 @@ reflect = branch-local gap+launch working memory -> CLAUDE.md/.claude/rules dura
 
 - gap/launch/verify 산출물과 legacy Spec Patch 자체는 repo-wide durable knowledge가 아닙니다.
 - repo에 영구적으로 남길 insight는 reflect를 통해서만 추출합니다.
-- `/tk:reflect` 기본 동작은 `apply=true`입니다.
+- `/tk:reflect` 기본 동작은 repo durable target이 안전하게 존재할 때 `apply=true`입니다. non-git/plain workspace에서는 proposal-only fallback이 기본입니다.
 - 반영할 durable insight가 없으면 아무 파일도 수정하지 않는 것이 정상 성공입니다.
 - source code는 수정하지 않습니다.
-- apply mode의 content write는 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에만 적용합니다.
+- apply mode의 content write는 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에만 적용합니다. 해당 target이 없거나 workflow가 preapprove하지 않은 plain workspace에서는 생성하지 않습니다.
 - branch recency bookkeeping으로 `global-index.json`의 branch entry를 생성하거나 `lastUsedAt`을 갱신할 수 있습니다.
 - branch-local specs/gap 산출물이 없다는 사실만으로 세션 관측 패턴을 durable insight 후보로 승격하지 않습니다.
 - 같은 insight를 중복 반영하지 않습니다.
@@ -70,6 +70,37 @@ Legacy `.claude/tigerkit/branches/<branch-key>/specs/`는 `/tk:gap`이 source ma
 - current code/worktree context needed to classify repo-wide value
 
 branch-local gap 산출물이 없으면 산출물 기반 후보는 없는 것으로 처리합니다. 이 경우에도 사용자 대화에서 명시적으로 확인된 TigerKit 운영 규칙은 후보가 될 수 있지만, legacy Spec Patch나 실행자 해석만으로 repo-wide durable insight를 만들지 않습니다.
+
+## Fallback reflect targets
+
+Reflect target tiers:
+
+```yaml
+reflect_targets:
+  repo_durable_rules:
+    available: true | false
+    paths:
+      - CLAUDE.md
+      - .claude/rules/**/*.md
+  workspace_generated_report:
+    available: true | false
+    path: .claude/tigerkit/branches/<scope-key>/reflect/current.md
+  user_memory_proposal:
+    available: host_specific
+    apply_default: false
+  meta_feedback:
+    available: true | false
+```
+
+Fallback defaults:
+
+- GitHub repo with durable rules: existing durable apply policy may run.
+- git repo without GitHub: durable apply is allowed only when rule files exist and policy permits.
+- non-git workspace with rule files: cautious apply only with preapproval; otherwise proposal-only.
+- non-git workspace without durable rule files: write generated reflect report and include `User-level Memory Candidates`; do not create durable rule files by default.
+- read-only workspace: stdout receipt only unless receipt persistence was required.
+
+User-level memory candidates are proposals by default. Host adapters such as Hermes may map them to a safe memory-review flow, but `/tk:reflect` must not auto-write host-global memory without explicit adapter support and user approval.
 
 ## Durable target classification
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -26,7 +26,11 @@
       "AUTOPILOT_NOT_IMPLEMENTED_IN_PHASE1",
       "OUT_OF_SCOPE_DIFF",
       "HYDRATION_CONFLICT",
-      "VERIFICATION_FAILED"
+      "VERIFICATION_FAILED",
+      "ARTIFACT_ROOT_UNWRITABLE",
+      "COMMIT_REQUIRED_UNAVAILABLE",
+      "GITHUB_REQUIRED_UNAVAILABLE",
+      "VERIFICATION_UNAVAILABLE"
     ],
     "phase_1_boundaries": [
       "Claude Code command-contract runner only",
@@ -39,7 +43,8 @@
     "plugin_version_policy": "Authoritative version is .claude-plugin/plugin.json; evals must not hard-code a concrete version literal.",
     "utility_commands": [
       "/tk:next"
-    ]
+    ],
+    "workspace_fallback": "GitHub, git, and commit are capabilities, not prerequisites; plain workspace scope uses workspace-<slug>--<hash>."
   },
   "evals": [
     {
@@ -308,6 +313,77 @@
         "Does not mutate source files",
         "Stdout-only in v8 MVP",
         "Uses side-effect-minimized git status inspection"
+      ]
+    },
+    {
+      "id": 14,
+      "name": "workspace-gap-ready-without-git",
+      "prompt": "Evaluate /tk:gap in a plain folder with no .git when enough source exists. Do not write files.",
+      "expected_output": "Should not fail merely because git rev-parse fails. Should use scope_kind=workspace, compute a stable workspace scope_key, write under .claude/tigerkit/branches/<scope-key>/ when writable, and produce GAP_READY with workspace_context when launchable. If artifacts are not writable, should block with ARTIFACT_ROOT_UNWRITABLE rather than pretending success.",
+      "files": [
+        "commands/gap.md",
+        ".tigerkit/docs/branch-local-contract.md",
+        ".tigerkit/docs/output-contract.md"
+      ],
+      "expectations": [
+        "Allows non-git workspace",
+        "Uses scope_kind workspace",
+        "Computes workspace scope_key",
+        "GAP_READY can be valid without git",
+        "Writable artifact root required",
+        "Does not require GitHub"
+      ]
+    },
+    {
+      "id": 15,
+      "name": "workspace-launch-success-skips-commit",
+      "prompt": "Evaluate /tk:launch for a GAP_READY workflow in a non-git workspace where verification passes and commit is not required. Do not write files.",
+      "expected_output": "Should execute the sealed workflow, pass verification, report SUCCESS, and record Commit: skipped_not_git_repo. Missing git/GitHub must not abort unless commit or PR is required by the workflow.",
+      "files": [
+        "commands/launch.md",
+        ".tigerkit/docs/output-contract.md",
+        ".tigerkit/docs/usage.md"
+      ],
+      "expectations": [
+        "SUCCESS allowed without git",
+        "Commit skipped_not_git_repo",
+        "Missing GitHub is not blocker",
+        "Commit required unavailable has explicit abort",
+        "PR required unavailable has explicit abort"
+      ]
+    },
+    {
+      "id": 16,
+      "name": "reflect-fallback-user-memory-proposal",
+      "prompt": "Evaluate /tk:reflect in a non-git workspace without CLAUDE.md or .claude/rules. Do not write files.",
+      "expected_output": "Should not create repo durable rule files by default. Should produce generated reflect report when possible and include User-level Memory Candidates or explicitly say none. Candidates are proposal-only and Auto-applied false unless a host adapter and user approval support memory writes.",
+      "files": [
+        "commands/reflect.md",
+        ".tigerkit/docs/output-contract.md",
+        ".tigerkit/docs/usage.md"
+      ],
+      "expectations": [
+        "No durable rule creation by default",
+        "Generated reflect report when writable",
+        "Includes user-level memory candidates",
+        "Auto-applied false",
+        "Proposal-only fallback"
+      ]
+    },
+    {
+      "id": 17,
+      "name": "non-code-workflow-task-and-verification-types",
+      "prompt": "Evaluate sealed workflow schema for non-code work such as docs/research/runbook generation. Do not write files.",
+      "expected_output": "Should allow task_type values such as docs_change, research, file_generation, data_cleanup, ops_runbook, communication_draft, analysis, and manual_receipt. Verification gates may use file_exists, file_contains, artifact_written, link_checked, schema_valid, manual_review_required, or receipt_only; code tests are not mandatory.",
+      "files": [
+        "commands/gap.md",
+        ".tigerkit/docs/output-contract.md"
+      ],
+      "expectations": [
+        "Allows non-code task types",
+        "Allows artifact verification gates",
+        "Does not require code tests",
+        "Manual review gate supported"
       ]
     }
   ]


### PR DESCRIPTION
## 요약
- 이슈: #90 TigerKit이 GitHub/git/commit 전제에 묶이지 않고 plain workspace에서도 GAP → Launch → Reflect를 수행해야 합니다.
- 수정: workspace fallback scope, commit skip semantics, non-code task/verification types, reflect proposal fallback을 command contracts/docs/evals에 추가했습니다.
- 검증: plugin validation, marketplace validation, JSON syntax, version check, diff check, package validate script를 통과했습니다.

Closes #90

## 변경 사항
- plugin version `8.1.0`
- `/tk:gap`
  - `workspace_context` schema 추가
  - `scope_kind=workspace` fallback 명시
  - non-code task types와 artifact/manual verification gate 허용
- `/tk:launch`
  - git/GitHub 부재를 기본 abort가 아닌 capability/skip reason으로 취급
  - `skipped_not_git_repo`, `skipped_no_github_remote`, `skipped_readonly_workspace`, `skipped_commit_policy_skip` 추가
  - commit/PR required unavailable abort codes 추가
  - non-git diff fallback policy 추가
- `/tk:reflect`
  - repo durable target이 없을 때 generated report + user-level memory candidate/proposal fallback 추가
  - host-global memory auto-write 금지
- branch/workspace-local contract
  - workspace scope key 규칙 추가
- output/artifact/usage/README/evals 업데이트

## 검증
```text
python3 scripts/bump-plugin-version.py --part minor
python3 scripts/check-plugin-version.py
claude plugin validate .claude-plugin/plugin.json
claude plugin validate .
python3 -m json.tool package.json >/dev/null
python3 -m json.tool evals/evals.json >/dev/null
python3 -m json.tool .claude-plugin/plugin.json >/dev/null
python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
git diff --check
npm run validate
```

## 참고
- `npm run validate`는 검증 환경에 yarn이 없어 같은 direct command chain을 실행하기 위해 사용했습니다. package script 내부에는 bun/npm recursion이 없습니다.
- Claude plugin validation의 root `CLAUDE.md` warning은 기존 구조 경고입니다.
