### PR TITLE
fix: add session start worktree context proposal

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "sealed GAP workflow, human-approved launch, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -163,7 +163,7 @@ Plain workspace fallback도 `branches/<scope-key>/next/` layout을 사용하고 
 
 ## Worktree context proposal artifacts
 
-Worktree context 후보 감지는 별도 SessionStart hook artifact를 만들지 않습니다. `/tk:launch`와 `/tk:next`는 각자의 receipt 안에 proposal-only 상태를 기록합니다.
+SessionStart worktree context check는 read-only hook입니다. Hook 자체는 symlink/copy/hydration artifact를 만들지 않고, `TIGERKIT_SESSION_START` additional context만 주입합니다. `/tk:gap`, `/tk:launch`, `/tk:next`는 session context 또는 matching decline marker를 소비합니다.
 
 기록 원칙:
 
@@ -171,6 +171,7 @@ Worktree context 후보 감지는 별도 SessionStart hook artifact를 만들지
 - 자동 symlink/copy 결과를 기록하지 않습니다. 적용은 별도 승인된 action이어야 합니다.
 - `$GIT_COMMON_DIR`, `.git/worktrees/*`, user home, `/tmp`에는 기록하지 않습니다.
 - `.claude/` 전체 symlink, tracked file symlink, regular file overwrite, `node_modules` symlink는 금지 정책으로 기록합니다.
+- 사용자가 거절한 동일 candidate signature는 `.claude/tigerkit/local/session-start/worktree-context-declines.json`에 기록해 다시 묻지 않을 수 있습니다.
 
 ## Maintainer-only artifacts
 

--- a/.tigerkit/docs/branch-local-contract.md
+++ b/.tigerkit/docs/branch-local-contract.md
@@ -153,7 +153,7 @@ Tiger Kit does not read or write files outside the current worktree by default.
 
 ## Worktree context proposal local context
 
-TigerKit은 worktree context를 Claude Code `SessionStart` hook으로 자동 symlink하지 않습니다. `/tk:launch` preflight와 `/tk:next` continuation scan은 current/base worktree를 비교해 proposal-only 상태를 각 command receipt에 기록합니다.
+TigerKit은 Claude Code `SessionStart` hook으로 worktree context를 세션 시작 시 한 번 read-only 점검합니다. Hook은 symlink/copy/hydration을 수행하지 않고 `TIGERKIT_SESSION_START` additional context만 주입합니다. `/tk:gap`은 이를 source grounding에 반영하고, `/tk:launch`와 `/tk:next`는 command마다 다시 묻지 않고 session context 또는 matching decline marker를 소비합니다.
 
 Proposal safety contract:
 
@@ -164,6 +164,7 @@ Proposal safety contract:
 - `.claude/` 전체 symlink와 `node_modules` symlink는 금지합니다.
 - source worktree를 수정하지 않습니다.
 - proposal 자체는 abort 사유가 아니지만, workflow가 context 적용을 required precondition으로 두고 승인/evidence가 없으면 `WORKTREE_CONTEXT_APPROVAL_REQUIRED`로 task 실행 전 중단합니다.
+- 사용자가 같은 candidate signature를 거절하면 `.claude/tigerkit/local/session-start/worktree-context-declines.json`에 기록해 다시 묻지 않을 수 있습니다.
 
 ## `/tk:launch` branch-local context
 

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -346,7 +346,8 @@ Concrete maintainer proof runs must recompute actual run proof from metadata bef
 - mid-flight 질문은 금지합니다. 새 결정이 필요하면 `HUMAN_DECISION_REQUIRED`로 abort합니다.
 - Phase 1에서 `--autopilot` recovery는 실행하지 않습니다.
 - commit은 preflight approval evidence 없이는 금지합니다.
-- worktree context 후보는 proposal-only로 기록합니다. 자동 symlink/copy는 하지 않습니다.
+- `TIGERKIT_SESSION_START` worktree context proposal은 SessionStart additional context에서 소비합니다. Command마다 같은 후보를 다시 스캔하거나 다시 묻지 않습니다.
+- 자동 symlink/copy는 하지 않습니다.
 - workflow가 worktree context 적용을 required precondition으로 두었는데 승인/evidence가 없으면 `WORKTREE_CONTEXT_APPROVAL_REQUIRED`로 task 실행 전 abort합니다.
 - required `tk-runner`/model harness가 unavailable이면 `MODEL_HARNESS_UNAVAILABLE`로 abort합니다.
 
@@ -379,6 +380,9 @@ worktree_context:
   proposal_only: true
   approval_required: true | false
   approval_present: true | false
+  candidate_signature: <sha256|null>
+  decline_marker: .claude/tigerkit/local/session-start/worktree-context-declines.json | null
+  suppressed_by_decline: true | false
 commit_created: false
 commit_status: created | skipped_preflight_required | skipped_not_requested | skipped_not_git_repo | skipped_no_github_remote | skipped_readonly_workspace | skipped_commit_policy_skip
 reflect_report_path: .claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -54,7 +54,7 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 사용자가 고칠 finding과 답할 clarification을 남깁니다. | branch-local |
 | `/tk:launch` | sealed workflow만 `tk-runner` subagent로 실행하고 verification, abort receipt, runtime harness, reflect trace를 남깁니다. git/GitHub/commit은 capability로 기록하고 필요 없으면 skip reason으로 성공할 수 있습니다. | branch/workspace-local execution |
 | `/tk:reflect` | gap+launch trace와 branch-local 산출물에서 repo에 남길 insight만 추출하고 반영합니다. | durable insight |
-| `/tk:next` | current state와 TigerKit artifact를 읽어 다음 안전 행동을 추천합니다. 실행·commit·PR은 하지 않습니다. | stdout utility |
+| `/tk:next` | current state와 TigerKit artifact를 읽어 다음 안전 실행 항목 하나를 실제로 이어서 시도하며 receipt를 남깁니다. | branch/workspace-local continuation execution |
 | `/tk:handoff` | 다음 세션이나 다음 작업자가 이어받을 수 있도록 continuation 문서를 작성합니다. | continuation |
 | `/tk:meta-feedback` | 현재 세션에서 드러난 TigerKit command/skill 개선안을 프로젝트 자산 유출 없이 일반화합니다. | generalized feedback |
 
@@ -82,7 +82,7 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 ## `/tk:gap`
 
 - 기본 `/tk:gap`은 v8.0에서 source intake, Ground / Attack / Produce workflow command입니다.
-- 사용자 의도, URL, ticket, notes, screenshots, repo context, prior specs, conversation decisions를 source material로 intake합니다.
+- 사용자 의도, URL, ticket, notes, screenshots, repo context, prior specs, conversation decisions, `SessionStart`의 `TIGERKIT_SESSION_START` worktree context proposal을 source material 후보로 intake합니다.
 - source material과 authority를 분리하고 confirmed requirement, assumption, rejected assumption, non-goal을 정규화합니다.
 - legacy branch-local Spec Patch가 있으면 active confirmed item만 source material 후보로 읽을 수 있습니다.
 - ambiguity attack으로 contradiction, missing decision, hidden dependency, edge case, failure mode, verification gap을 찾습니다.
@@ -138,7 +138,7 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 - workflow 밖 scope 확장, missing requirement 임의 해석, public API/DB/product behavior 재정의, verification 없는 success 선언, out-of-scope diff commit을 금지합니다.
 - mid-flight 질문을 하지 않습니다. 새 사용자 결정이 필요하면 `HUMAN_DECISION_REQUIRED`로 abort합니다.
 - `/tk:launch --autopilot`은 Phase 1에서 recovery를 수행하지 않고 `AUTOPILOT_DISABLED` 또는 `AUTOPILOT_NOT_IMPLEMENTED_IN_PHASE1`로 abort합니다.
-- `/tk:launch`는 linked worktree에서 base worktree에만 있는 root-level Markdown과 `.claude/` 후보를 proposal-only로 기록합니다. 자동 symlink/copy는 하지 않습니다.
+- `/tk:launch`는 `SessionStart`가 주입한 `TIGERKIT_SESSION_START` worktree context proposal을 preflight capability로 기록합니다. 자동 symlink/copy는 하지 않으며, 같은 candidate signature를 command마다 다시 묻지 않습니다.
 - workflow가 worktree context 적용을 required precondition으로 두었는데 승인/evidence가 없으면 `WORKTREE_CONTEXT_APPROVAL_REQUIRED`로 task 실행 전 abort합니다.
 - `/tk:launch`는 `tk-runner` runtime harness를 receipt에 기록합니다. Claude Code 배포 agent는 `model: sonnet`이며, unavailable/fallback 상태를 숨기지 않습니다.
 - commit은 preflight receipt에 `user_preapproved_commit=true`와 `approval_source_ref`가 있을 때만 가능합니다.
@@ -178,12 +178,11 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 
 ## `/tk:next`
 
-- `/tk:next`는 GAP → Launch → Reflect pipeline 밖의 utility command입니다.
-- current workspace/repo state, latest GAP workflow/status, latest launch receipt, latest reflect report, latest handoff를 읽고 다음 안전 행동 하나를 추천합니다.
-- source file, durable rule, commit, PR을 만들지 않습니다.
-- MVP 동작은 stdout-only입니다. `.claude/tigerkit/.../next/` artifact를 쓰지 않습니다.
-- output은 `Next Action`, `Status`, `Recommended Command`, `Why`, `Blocked By`, `References` 중심입니다.
-- 추천 상태는 `recommended`, `blocked`, `optional`, `manual`, `none` 중 하나입니다.
+- `/tk:next`는 GAP → Launch → Reflect pipeline 밖의 steering replacement continuation command입니다.
+- current workspace/repo state, latest GAP workflow/status, latest launch receipt, latest reflect report, latest handoff, `SessionStart` worktree context proposal을 읽고 다음 안전 실행 항목 하나를 선택합니다.
+- 안전하게 할 수 있는 작업이 있으면 시도하고, 할 수 없으면 `NEXT_BLOCKED`, `NEXT_PARTIAL`, `NEXT_SKIPPED` 중 하나로 멈춘 이유를 남깁니다.
+- 사용자 승인 또는 artifact상의 명시 approval 없이 commit, PR, GitHub issue write, worktree context symlink/copy를 수행하지 않습니다.
+- 같은 worktree context candidate signature가 이미 거절되었으면 다시 묻지 않습니다.
 
 ## `/tk:handoff`
 
@@ -208,7 +207,7 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 
 ## Worktree context proposal
 
-TigerKit은 Git worktree context를 Claude Code `SessionStart` hook으로 자동 symlink하지 않습니다. `/tk:launch` preflight와 `/tk:next` continuation scan에서 base/source worktree에만 있는 root-level Markdown(`AGENTS.md`, `CLAUDE.local.md`, `DESIGN.md` 등)과 `.claude/` 후보를 감지해 proposal-only로 기록합니다.
+TigerKit은 Git worktree context를 Claude Code `SessionStart` hook으로 세션 시작 시 한 번 read-only 점검합니다. Hook은 base/source worktree에만 있는 root-level Markdown(`AGENTS.md`, `CLAUDE.local.md`, `DESIGN.md` 등)과 `.claude/` 후보를 `TIGERKIT_SESSION_START` additional context로 제안합니다. `/tk:gap`은 이를 source grounding에 포함하고, `/tk:launch`와 `/tk:next`는 command마다 다시 묻지 않습니다.
 
 안전 정책:
 
@@ -218,7 +217,7 @@ TigerKit은 Git worktree context를 Claude Code `SessionStart` hook으로 자동
 - `.claude/` 전체 symlink 금지
 - `node_modules` symlink 금지
 - `DESIGN.md`는 branch-specific 가능성이 있어 copy/skip 검토 권장
-- plugin root `CLAUDE.md`는 Claude Code project context로 자동 로드된다고 의존하지 않음
+- 같은 candidate signature를 거절하면 `.claude/tigerkit/local/session-start/worktree-context-declines.json`에 기록해 다시 묻지 않음
 
 ## Generated state
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
 - `/tk:next`는 현재 TigerKit artifact와 workspace/repo 상태를 읽어 handoff/trace의 다음 안전 작업을 실제로 이어서 시도하는 steering replacement continuation command다. sealed workflow가 필요한 구현은 `/tk:gap → /tk:launch`를 우회하지 않으며, commit/push/PR/merge/release/deploy 같은 외부 side effect는 사용자 승인 또는 artifact상의 명시 approval 없이는 수행하지 않는다.
 - `/tk:handoff`는 다음 세션이나 다음 작업자가 이어받을 continuation 문서를 작성한다.
 - `/tk:meta-feedback`은 현재 세션 내역에서 TigerKit command/skill 개선안을 일반화해 추출한다.
-- Git worktree context 처리는 자동 SessionStart hook이 아니라 `/tk:launch` preflight와 `/tk:next` continuation scan에서 proposal-only로 다룬다. base worktree에만 있는 root-level Markdown과 `.claude/` 후보를 제안하되, tracked file symlink, regular file overwrite, `.claude/` 전체 symlink, `node_modules` symlink, source_worktree mutation은 금지한다.
+- Git worktree context 처리는 Superpowers-style `SessionStart` read-only context check로 세션 시작 시 한 번 감지한다. base/source worktree에만 있는 root-level Markdown과 `.claude/` 후보를 `additionalContext`로 제안하되 자동 symlink/hydration은 금지한다. `/tk:gap`은 이 context를 source grounding에 반영하고, `/tk:launch`와 `/tk:next`는 command마다 재질문하지 말고 session context 또는 decline marker를 소비한다. 사용자가 같은 candidate signature를 거절하면 `.claude/tigerkit/local/session-start/worktree-context-declines.json`에 기록해 다시 묻지 않는다. tracked file symlink, regular file overwrite, `.claude/` 전체 symlink, `node_modules` symlink, source_worktree mutation은 금지한다.
 - repo convention은 `.claude/rules/**/*.md`를 우선 확인한다.
 - UI copy는 basis 또는 confirmed contract와 exact match여야 한다. 의미상 유사함은 충분하지 않다.
 - 외부 근거는 URL, path, ticket, Figma, PRD, issue, API docs, source code path, commit hash 같은 reference와 access status로 관리한다.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
 
 `/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY` 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
 
-GitHub remote, git branch, commit 가능 여부는 launch preflight capability로 기록하며 prerequisite가 아닙니다. commit/PR이 불가능해도 workflow가 commit/PR을 요구하지 않으면 `/tk:launch`는 `Commit: skipped_not_git_repo` 같은 명시 skip reason으로 성공할 수 있습니다. Git worktree context는 자동 hook으로 symlink하지 않고, `/tk:launch`와 `/tk:next`가 base worktree에만 있는 root-level Markdown과 `.claude/` 후보를 proposal-only로 제안합니다.
+GitHub remote, git branch, commit 가능 여부는 launch preflight capability로 기록하며 prerequisite가 아닙니다. commit/PR이 불가능해도 workflow가 commit/PR을 요구하지 않으면 `/tk:launch`는 `Commit: skipped_not_git_repo` 같은 명시 skip reason으로 성공할 수 있습니다. Git worktree context는 Superpowers-style `SessionStart` read-only hook이 세션 시작 시 한 번 점검하고, base/source worktree에만 있는 root-level Markdown과 `.claude/` 후보를 `additionalContext`로 proposal-only 제안합니다. `/tk:gap`은 이 context를 source grounding에 포함하고, `/tk:launch`와 `/tk:next`는 command마다 같은 후보를 다시 묻지 않습니다. 사용자가 거절한 동일 candidate signature는 `.claude/tigerkit/local/session-start/worktree-context-declines.json`로 suppress합니다.
 
 `/tk:next`는 primary execution pipeline을 대체하지 않는 steering replacement continuation command입니다. 현재 TigerKit artifact와 workspace 상태를 읽어 handoff/trace의 다음 안전 작업을 실제로 이어서 시도하고, commit/push/PR/merge/release/deploy/GitHub issue write 같은 외부 side effect는 사용자 승인 또는 artifact상의 명시 approval 없이는 수행하지 않습니다.
 

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -81,6 +81,19 @@ workspace_context:
 
 If git is unavailable, use `scope_kind=workspace` and compute `scope_key = workspace-<basename-slug>--<sha256(absWorkspaceRoot).slice(0, 8)>`. Missing git or GitHub is not a blocker unless the requested workflow explicitly requires commit or PR behavior.
 
+## SessionStart worktree context
+
+If the session includes `TIGERKIT_SESSION_START` additional context from the TigerKit `SessionStart` hook, treat it as source-grounding context.
+
+Rules:
+
+- Include the worktree context proposal in source material discovery and source grounding.
+- Record the candidate signature and decline marker path when relevant.
+- Do not turn proposal candidates into confirmed requirements without user decision or explicit source basis.
+- Do not ask again about the same candidate signature when the session context says it was declined or a matching decline marker exists.
+- Do not symlink, copy, hydrate, or mutate worktree context during `/tk:gap`.
+- If the missing context may affect launch workflow quality, encode it as a preflight assumption, human decision, missing source, or abort condition rather than silently ignoring it.
+
 Sealed workflow tasks are not limited to code changes. Allowed task types include:
 
 ```text

--- a/commands/launch.md
+++ b/commands/launch.md
@@ -41,19 +41,15 @@ launch = preflight + tk-runner sealed workflow execution + verify gates + abort 
 
 ## Worktree context proposal preflight
 
-TigerKit은 Claude Code `SessionStart` hook으로 symlink/hydration을 자동 실행하지 않습니다. Plugin root `CLAUDE.md`도 Claude Code project context로 자동 로드된다고 가정하지 않습니다. Worktree context 처리는 `/tk:launch` preflight 또는 `/tk:next` continuation scan에서 **proposal-only**로 수행합니다.
+TigerKit은 Claude Code `SessionStart` hook으로 worktree context를 세션 시작 시 한 번 read-only 점검합니다. Plugin root `CLAUDE.md`가 Claude Code project context로 자동 로드된다고 가정하지 않습니다. `/tk:launch`는 command마다 같은 후보를 다시 스캔하거나 다시 묻지 않고, 세션의 `TIGERKIT_SESSION_START` additional context 또는 matching decline marker를 소비합니다.
 
-Preflight 감지:
+Preflight 처리:
 
-1. current root가 linked git worktree인지 확인합니다.
-2. source/base worktree 후보를 찾습니다. 우선순위는 아래와 같습니다.
-   - sealed workflow의 `worktree_policy.source_worktree` 또는 `workspace_context.source_worktree`
-   - `git worktree list --porcelain`에서 같은 repository의 primary/main-like worktree 후보
-   - 사용자가 command argument나 preflight approval로 제공한 absolute path
-3. source/base root에는 있고 current root에는 없는 root-level `*.md` / `*.MD` 파일을 후보로 나열합니다.
-4. source/base root에 `.claude/`가 있고 current root에 없으면 후보로 나열합니다.
-5. 자동 symlink/copy를 수행하지 않습니다.
-6. proposal은 launch receipt의 `worktree_context`에 기록합니다.
+1. session context에 `TIGERKIT_SESSION_START`가 있는지 확인합니다.
+2. context에 있는 candidate signature, source/base worktree, missing root Markdown, missing `.claude/` 후보를 receipt의 `worktree_context`에 기록합니다.
+3. matching decline marker가 있으면 worktree context proposal을 suppressed로 기록하고 다시 묻지 않습니다.
+4. 자동 symlink/copy를 수행하지 않습니다.
+5. workflow가 missing worktree context를 required precondition으로 명시했는데 승인/적용 evidence가 없으면 `WORKTREE_CONTEXT_APPROVAL_REQUIRED`로 task 실행 전 abort합니다.
 
 Proposal safety policy:
 
@@ -135,7 +131,7 @@ runtime_harness:
 5. `tigerkit-gap-status`와 `branch-state.json`에 기록된 외부 `workflow_sha256`과 계산값을 비교합니다. `tigerkit-launch-workflow` 내부 자기참조 hash는 사용하지 않습니다.
 6. `status`가 `GAP_READY`인지 확인합니다.
 7. `source_refs`, `requirements`, `tasks`, `verification_gates`, `abort_policy`, `commit_policy`를 확인합니다.
-8. worktree context 후보를 proposal-only로 감지하고 receipt에 기록합니다.
+8. `TIGERKIT_SESSION_START` worktree context proposal 또는 matching decline marker를 확인하고 receipt에 기록합니다. Command마다 같은 후보를 다시 스캔하거나 다시 묻지 않습니다.
 9. workflow가 worktree context를 required precondition으로 명시했으면 approval/apply evidence가 있는지 확인합니다.
 10. runtime harness를 확인합니다. `tk-runner` subagent를 사용할 수 있는지, fallback 허용 여부, model binding 관측 가능성을 기록합니다.
 11. `autopilot_policy.enabled`가 false인데 `--autopilot`이면 abort합니다.

--- a/commands/next.md
+++ b/commands/next.md
@@ -42,24 +42,22 @@ next = inspect continuation state + select next safe executable work item + atte
 - handoff `Pending Work`, `Pending Backlog`, `Next Actions`, `Resume Prompt`
 - launch abort receipt와 failed task/gate
 - reflect `Needs more evidence`, proposal-only follow-up, TigerKit meta-feedback
-- worktree context candidates from current/base worktree comparison
+- `TIGERKIT_SESSION_START` worktree context proposal from SessionStart additional context, plus matching decline marker when present
 - current git status when git is available, using side-effect-minimized inspection such as `git --no-optional-locks status --porcelain=v1 -b`
 - explicit user-provided goal/context in the command arguments
 
 Missing artifacts are not fatal by themselves. Treat them as evidence for either a safe next action or `NEXT_BLOCKED`.
 
-## Worktree context candidate scan
+## Worktree context session proposal
 
-`/tk:next`는 SessionStart hook이나 plugin root `CLAUDE.md`에 의존하지 않습니다. 필요하면 current worktree와 base/source worktree 후보를 비교해 context 후보를 proposal-only로 정리합니다.
+`/tk:next`는 command마다 worktree 후보를 다시 스캔하거나 다시 묻지 않습니다. SessionStart hook이 주입한 `TIGERKIT_SESSION_START` additional context 또는 matching decline marker를 소비합니다.
 
-Scan policy:
+Session policy:
 
-1. current root가 linked git worktree인지 확인합니다.
-2. source/base worktree 후보를 찾습니다.
-3. base root에는 있고 current root에는 없는 root-level `*.md` / `*.MD` 파일을 찾습니다.
-4. base root에 `.claude/`가 있고 current root에 없으면 후보로 표시합니다.
-5. 자동 symlink/copy를 수행하지 않습니다.
-6. 승인 없이 regular file overwrite, tracked file symlink, `.claude/` 전체 symlink, `node_modules` symlink를 수행하지 않습니다.
+1. `TIGERKIT_SESSION_START` context가 있으면 candidate signature, source/base worktree, missing root Markdown, missing `.claude/` 후보를 읽습니다.
+2. matching decline marker가 있으면 proposal을 suppressed로 처리하고 다시 묻지 않습니다.
+3. 자동 symlink/copy를 수행하지 않습니다.
+4. 승인 없이 regular file overwrite, tracked file symlink, `.claude/` 전체 symlink, `node_modules` symlink를 수행하지 않습니다.
 
 Safe next action examples:
 
@@ -74,7 +72,7 @@ Safe next action examples:
 
 1. User-provided explicit next goal/context가 있으면 그것을 우선합니다.
 2. latest handoff의 `Pending Work`와 `Next Actions`를 우선합니다.
-3. worktree context 후보가 있고 launch/verification에 영향을 줄 수 있으면 proposal receipt 작성 또는 승인 필요 상태로 정리합니다.
+3. `TIGERKIT_SESSION_START` worktree context proposal이 있고 launch/verification에 영향을 줄 수 있으면 session context를 receipt에 반영하거나 승인 필요 상태로 정리합니다. 같은 candidate signature를 command마다 다시 묻지 않습니다.
 4. launch가 `ABORTED`이면 abort receipt의 next action과 failed task/gate를 우선합니다.
 5. reflect가 proposal-only follow-up이나 `Needs more evidence`를 남겼으면 안전한 정리/문서/확인 작업을 선택합니다.
 6. latest GAP이 `GAP_BLOCKED`이면 blocking decision/source를 해결할 수 있는 repo-local 확인 작업만 수행합니다. 인간 결정이 필요하면 차단합니다.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -39,7 +39,7 @@
       "no Hermes plugin command adapter in MVP",
       "no Codex CLI adapter in MVP",
       "autopilot recovery disabled",
-      "worktree context handling is proposal-only with no SessionStart hook side effects",
+      "worktree context handling is read-only SessionStart proposal with no automatic symlink/copy side effects",
       "launch uses tk-runner Claude Code agent with sonnet binding when subagents are available"
     ],
     "plugin_version_policy": "Authoritative version is .claude-plugin/plugin.json; evals must not hard-code a concrete version literal.",
@@ -251,25 +251,31 @@
     },
     {
       "id": 11,
-      "name": "worktree-context-proposal-does-not-auto-symlink",
-      "prompt": "Evaluate /tk:launch --worktree preflight when a base worktree has root Markdown files and .claude/ that are missing in the current linked worktree. Do not write source files.",
-      "expected_output": "Should not run startup hook side effects, create symlinks, overwrite regular files, mutate source_worktree, or write local startup receipts. Should detect base-only root-level Markdown and .claude/ as proposal-only worktree context candidates. /tk:launch should continue unless the sealed workflow marks context application as a required precondition; in that case it should abort before task execution with WORKTREE_CONTEXT_APPROVAL_REQUIRED.",
+      "name": "session-start-worktree-context-proposal-read-only",
+      "prompt": "Evaluate SessionStart worktree context proposal when a base worktree has root Markdown files and .claude/ that are missing in the current linked worktree. Do not write source files.",
+      "expected_output": "Should register a SessionStart read-only hook that injects TIGERKIT_SESSION_START additional context with candidate signature, source/base worktree, base-only root-level Markdown candidates, base-only .claude/ candidate, safety contract, and decline marker path. It must not create symlinks, copy files, overwrite regular files, mutate source_worktree, or hydrate context automatically. /tk:gap should consume this context during source grounding. /tk:launch and /tk:next should consume the session context or matching decline marker instead of re-asking per command.",
       "files": [
         "hooks/hooks.json",
+        "hooks/session-start",
+        "hooks/run-hook.cmd",
+        "commands/gap.md",
         "commands/launch.md",
+        "commands/next.md",
         ".tigerkit/docs/artifact-layout.md",
         ".tigerkit/docs/branch-local-contract.md"
       ],
       "expectations": [
-        "SessionStart hook is empty",
-        "No local startup receipt",
+        "SessionStart read-only hook exists",
+        "Injects TIGERKIT_SESSION_START additional context",
+        "Includes candidate signature",
+        "Includes decline marker path",
         "Detects base-only root Markdown candidates",
         "Detects missing .claude candidate",
-        "Proposal-only by default",
         "Does not mutate source_worktree",
         "Does not overwrite regular files",
-        "Does not symlink tracked files by default",
-        "Abort code WORKTREE_CONTEXT_APPROVAL_REQUIRED only when context is required"
+        "Does not symlink or copy files automatically",
+        "/tk:gap consumes session context during source grounding",
+        "/tk:launch and /tk:next do not re-ask per command"
       ]
     },
     {
@@ -303,7 +309,7 @@
       "id": 13,
       "name": "next-command-attempts-continuation-with-approval-gates",
       "prompt": "Evaluate /tk:next when latest handoff or launch/reflect trace contains a safe next work item. Do not create commits or PRs.",
-      "expected_output": "Should inspect current TigerKit artifacts and worktree context candidates, select one safe executable next item, attempt it within existing command contracts, and write a NEXT_DONE, NEXT_PARTIAL, NEXT_BLOCKED, or NEXT_SKIPPED receipt. Should not be stdout-only or recommendation-only. Should not execute /tk:launch, commit, PR, merge, release, deploy, GitHub issue writes, or worktree context symlink/copy without explicit approval.",
+      "expected_output": "Should inspect current TigerKit artifacts and any TIGERKIT_SESSION_START worktree context proposal, select one safe executable next item, attempt it within existing command contracts, and write a NEXT_DONE, NEXT_PARTIAL, NEXT_BLOCKED, or NEXT_SKIPPED receipt. Should not be stdout-only or recommendation-only. Should not execute /tk:launch, commit, PR, merge, release, deploy, GitHub issue writes, re-ask the same worktree candidate signature, or apply worktree context symlink/copy without explicit approval.",
       "files": [
         "commands/next.md",
         ".tigerkit/docs/output-contract.md",
@@ -313,7 +319,7 @@
       ],
       "expectations": [
         "Inspects handoff/gap/launch/reflect artifacts",
-        "Inspects worktree context candidates",
+        "Consumes TIGERKIT_SESSION_START worktree context when present",
         "Selects one safe executable item",
         "Attempts safe continuation work",
         "Writes next receipt",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,3 +1,16 @@
 {
-  "hooks": {}
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" session-start",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,45 @@
+: << 'CMDBLOCK'
+@echo off
+REM Cross-platform polyglot wrapper for TigerKit hook scripts.
+REM On Windows: cmd.exe runs this batch portion and locates bash.
+REM On Unix: sh/bash treats the block above CMDBLOCK as a no-op heredoc.
+REM
+REM Hook scripts use extensionless filenames so Claude Code's Windows .sh
+REM auto-detection does not rewrite the command.
+REM
+REM Usage: run-hook.cmd <script-name> [args...]
+
+if "%~1"=="" (
+    echo run-hook.cmd: missing script name >&2
+    exit /b 1
+)
+
+set "HOOK_DIR=%~dp0"
+
+if exist "C:\Program Files\Git\bin\bash.exe" (
+    "C:\Program Files\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+if exist "C:\Program Files (x86)\Git\bin\bash.exe" (
+    "C:\Program Files (x86)\Git\bin\bash.exe" "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+where bash >nul 2>nul
+if %ERRORLEVEL% equ 0 (
+    bash "%HOOK_DIR%%~1" %2 %3 %4 %5 %6 %7 %8 %9
+    exit /b %ERRORLEVEL%
+)
+
+REM No bash found: fail open so the plugin commands remain usable.
+exit /b 0
+CMDBLOCK
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="${1:-}"
+if [ -z "$SCRIPT_NAME" ]; then
+  echo "run-hook.cmd: missing script name" >&2
+  exit 1
+fi
+shift
+exec bash "${SCRIPT_DIR}/${SCRIPT_NAME}" "$@"

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# TigerKit SessionStart hook.
+# Performs a read-only worktree context check and injects a one-time proposal
+# when the current linked worktree appears to be missing root-level agent context.
+
+set -u
+
+escape_for_json() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+emit_context() {
+  local raw_context="$1"
+  local context
+  context="$(escape_for_json "$raw_context")"
+
+  if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+    printf '{\n  "additional_context": "%s"\n}\n' "$context"
+  elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$context"
+  else
+    printf '{\n  "additionalContext": "%s"\n}\n' "$context"
+  fi
+}
+
+emit_empty() {
+  emit_context ""
+}
+
+abs_dir() {
+  local dir="$1"
+  [ -d "$dir" ] || return 1
+  (cd "$dir" 2>/dev/null && pwd -P) || return 1
+}
+
+hash_text() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  else
+    printf '%s' "unavailable"
+  fi
+}
+
+extract_cwd_from_stdin() {
+  local payload="$1"
+  if command -v python3 >/dev/null 2>&1 && [ -n "$payload" ]; then
+    HOOK_PAYLOAD="$payload" python3 - <<'PY' 2>/dev/null || true
+import json, os
+payload = os.environ.get("HOOK_PAYLOAD", "")
+try:
+    data = json.loads(payload)
+except Exception:
+    data = {}
+for key in ("cwd", "workspaceRoot", "workspace_root", "projectRoot", "project_root"):
+    value = data.get(key)
+    if isinstance(value, str) and value:
+        print(value)
+        break
+PY
+  fi
+}
+
+is_declined() {
+  local marker="$1"
+  local signature="$2"
+  [ -f "$marker" ] || return 1
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$marker" "$signature" <<'PY' 2>/dev/null
+import json, sys
+path, sig = sys.argv[1], sys.argv[2]
+try:
+    data = json.load(open(path, encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+for item in data.get("declines", []):
+    if item.get("signature") == sig:
+        sys.exit(0)
+sys.exit(1)
+PY
+    return $?
+  fi
+  grep -Fq "\"signature\"" "$marker" && grep -Fq "$signature" "$marker"
+}
+
+hook_input="$(cat 2>/dev/null || true)"
+input_cwd="$(extract_cwd_from_stdin "$hook_input")"
+workspace_root="${TIGERKIT_WORKSPACE_ROOT:-${input_cwd:-$PWD}}"
+workspace_root="$(abs_dir "$workspace_root" 2>/dev/null || true)"
+[ -n "$workspace_root" ] || { emit_empty; exit 0; }
+
+if ! command -v git >/dev/null 2>&1; then
+  emit_empty
+  exit 0
+fi
+
+repo_root="$(git -C "$workspace_root" rev-parse --show-toplevel 2>/dev/null || true)"
+repo_root="$(abs_dir "${repo_root:-$workspace_root}" 2>/dev/null || true)"
+[ -n "$repo_root" ] || { emit_empty; exit 0; }
+
+worktree_output="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null || true)"
+[ -n "$worktree_output" ] || { emit_empty; exit 0; }
+
+current_root="$repo_root"
+worktree_count="$(printf '%s\n' "$worktree_output" | awk '/^worktree / { count++ } END { print count+0 }')"
+[ "$worktree_count" -gt 1 ] || { emit_empty; exit 0; }
+
+source_worktree="$(printf '%s\n' "$worktree_output" | awk -v cur="$current_root" '
+  /^worktree / {
+    path = substr($0, 10)
+    if (path != cur && first == "") first = path
+  }
+  END { print first }
+')"
+source_worktree="$(abs_dir "$source_worktree" 2>/dev/null || true)"
+[ -n "$source_worktree" ] || { emit_empty; exit 0; }
+[ "$source_worktree" != "$current_root" ] || { emit_empty; exit 0; }
+
+candidates=""
+for path in "$source_worktree"/*.md "$source_worktree"/*.MD; do
+  [ -f "$path" ] || continue
+  name="$(basename "$path")"
+  [ -e "$current_root/$name" ] && continue
+  case "$name" in
+    DESIGN.md|design.md|DESIGN.MD)
+      action="copy_or_skip_candidate"
+      reason="DESIGN.md may be branch-specific; inspect before sharing."
+      ;;
+    *)
+      action="inspect_then_symlink_or_copy_candidate"
+      reason="base/source worktree has root-level Markdown context missing from this worktree."
+      ;;
+  esac
+  candidates="${candidates}- path: ${name}\n  action: ${action}\n  reason: ${reason}\n"
+done
+
+current_claude_has_user_content=false
+if [ -d "$current_root/.claude" ]; then
+  if find "$current_root/.claude" -mindepth 1 \
+    ! -path "$current_root/.claude/tigerkit" \
+    ! -path "$current_root/.claude/tigerkit/*" \
+    -print -quit 2>/dev/null | grep -q .; then
+    current_claude_has_user_content=true
+  fi
+fi
+
+if [ -d "$source_worktree/.claude" ] && [ "$current_claude_has_user_content" != "true" ]; then
+  candidates="${candidates}- path: .claude/\n  action: inspect_selected_children_only\n  reason: base/source worktree has .claude/ but full-directory symlink is forbidden.\n"
+fi
+
+[ -n "$candidates" ] || { emit_empty; exit 0; }
+
+signature_payload="current=${current_root}
+source=${source_worktree}
+${candidates}"
+signature="$(hash_text "$signature_payload")"
+decline_marker="${current_root}/.claude/tigerkit/local/session-start/worktree-context-declines.json"
+if is_declined "$decline_marker" "$signature"; then
+  emit_empty
+  exit 0
+fi
+
+context="<TIGERKIT_SESSION_START>
+TigerKit ran a read-only worktree context check for this session.
+
+Status: WORKTREE_CONTEXT_PROPOSAL
+Current root: ${current_root}
+Source/base worktree: ${source_worktree}
+Candidate signature: ${signature}
+Decline marker: .claude/tigerkit/local/session-start/worktree-context-declines.json
+
+Detected missing context candidates:
+${candidates}
+Safety contract:
+- Do not automatically symlink, copy, hydrate, or mutate files from this hook.
+- Do not mutate the source/base worktree.
+- Never symlink tracked files by default.
+- Never overwrite regular files.
+- Never symlink .claude/ as a whole directory.
+- Never symlink node_modules by default.
+- If the user declines this proposal, record the candidate signature in the decline marker and do not ask again for the same signature.
+
+Command behavior:
+- /tk:gap should consider this proposal during source grounding and sealed workflow creation.
+- /tk:launch should consume this session context during preflight instead of re-prompting per command.
+- /tk:next should not re-ask about the same proposal when this session context or a matching decline marker exists.
+</TIGERKIT_SESSION_START>"
+
+emit_context "$context"
+exit 0


### PR DESCRIPTION
## 요약
- 이슈: #98 worktree context 제안을 command마다 재스캔/재질문하는 대신 Superpowers-style SessionStart read-only 루틴으로 한 번만 처리해야 했습니다.
- 수정: SessionStart hook이 `TIGERKIT_SESSION_START` additional context를 주입하고, `/tk:gap`은 source grounding에 반영하며 `/tk:launch`와 `/tk:next`는 session context/decline marker를 소비하도록 정렬했습니다.
- 검증: plugin validate, JSON 검증, diff check, hook syntax, linked worktree proposal + decline suppression fixture를 통과했습니다. `yarn`은 환경에 없어 package validate command chain을 직접 실행했습니다.

Closes #98

## 변경 사항
- `hooks/hooks.json`에 `SessionStart` read-only hook 등록
- `hooks/run-hook.cmd`, `hooks/session-start` 추가
- linked worktree에서 base/source에만 있는 root-level Markdown과 `.claude/` 후보를 `TIGERKIT_SESSION_START` additional context로 제안
- candidate signature와 decline marker 경로 추가
- 같은 candidate signature가 decline marker에 있으면 빈 context로 suppression
- `/tk:gap`에 SessionStart worktree context source grounding 규칙 추가
- `/tk:launch`, `/tk:next`가 command마다 같은 후보를 다시 묻지 않도록 계약 수정
- docs/evals 동기화
- plugin version `8.1.3` bump

## 검증
```text
claude plugin validate .claude-plugin/plugin.json
claude plugin validate .
git diff --cached --check
python3 -m json.tool evals/evals.json >/dev/null
python3 -m json.tool hooks/hooks.json >/dev/null
python3 -m json.tool .claude-plugin/plugin.json >/dev/null
python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
python3 scripts/check-plugin-version.py
bash -n hooks/session-start
bash -n hooks/run-hook.cmd
linked worktree fixture: proposal emits TIGERKIT_SESSION_START, decline marker suppresses repeat prompt
```

## 참고
- `claude plugin validate .`는 기존 root `CLAUDE.md` warning만 출력하고 통과했습니다.
- 로컬 untracked `tmux-client-*.log` 파일은 PR에 포함하지 않았습니다.
