### PR TITLE
feat: add tk review command surface

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "MTGVim"
   },
   "metadata": {
-    "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
+    "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, review verdict, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
   },
   "plugins": [
     {
       "name": "tk",
       "source": "./",
-      "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
+      "description": "branch-scoped source intake, sealed GAP workflow, human-approved launch, review verdict, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,14 @@
 {
   "name": "tk",
-  "description": "sealed GAP workflow, human-approved launch, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "9.0.1",
+  "description": "sealed GAP workflow, human-approved launch, review verdict, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
+  "version": "10.0.0",
   "author": {
     "name": "MTGVim"
   },
   "commands": [
     "./commands/gap.md",
     "./commands/launch.md",
+    "./commands/review.md",
     "./commands/reflect.md",
     "./commands/next.md",
     "./commands/meta-feedback.md",

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -24,6 +24,9 @@ TigerKit은 branch-local working memory와 durable insight를 분리합니다.
         launch/
           LCH-YYYYMMDD-HHmmss-RAND.md
           current.md
+        review/
+          RVW-YYYYMMDD-HHmmss-RAND.md
+          current.md
         reflect/
           RFL-YYYYMMDD-HHmmss-RAND.md
           current.md
@@ -81,6 +84,8 @@ MVP에서는 path compatibility를 위해 `branches/` 아래에 저장하지만 
 | `.claude/tigerkit/branches/<branch-key>/gap/<GAP-ID>.md` | `/tk:gap`이 `GAP_BLOCKED`일 때 만드는 blocked report입니다. workflow block을 포함하지 않습니다. | branch-local |
 | `.claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md` | `/tk:launch` 실행 또는 abort report입니다. | branch-local execution |
 | `.claude/tigerkit/branches/<branch-key>/launch/current.md` | launch status, task/gate 결과, abort code, commit decision을 보존하는 최소 run record입니다. | branch-local execution |
+| `.claude/tigerkit/branches/<branch-key>/review/<RVW-ID>.md` | `/tk:review`가 frozen target 대비 구현 결과를 검증해 verdict, closed gaps, remaining gaps, drift/risk, next recommendation을 기록하는 report입니다. | branch-local review |
+| `.claude/tigerkit/branches/<branch-key>/review/current.md` | 최신 review report copy입니다. | branch-local pointer |
 | `.claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md` | `/tk:reflect` generated report archive입니다. `tigerkit-reflect-report` block을 포함합니다. durable apply가 아닙니다. | branch-local generated |
 | `.claude/tigerkit/branches/<branch-key>/reflect/current.md` | 최신 reflect report copy입니다. | branch-local pointer |
 | `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md` | `/tk:gap --review` 사용자가 읽는 compatibility gap report 본문입니다. Actionable Findings, Clarification Needed, next action 중심입니다. | branch-local |
@@ -148,6 +153,21 @@ proof.json
 - artifact inventory dump
 
 확인하지 못한 target/producer/plan surface가 사용자 결정을 막으면 proof dump가 아니라 `Clarification Needed` 또는 `Not Accepted Summary`로 표현합니다.
+
+
+## `/tk:review` artifact policy
+
+`/tk:review`는 post-launch verification run마다 generated report를 남깁니다. 기본 위치는 아래와 같습니다.
+
+```text
+.claude/tigerkit/branches/<branch-key>/review/
+  RVW-YYYYMMDD-HHmmss-RAND.md
+  current.md
+```
+
+Plain workspace fallback도 `branches/<scope-key>/review/` layout을 사용하고 receipt에 `Scope Kind: workspace`를 표시합니다. review report는 branch/workspace-local generated working memory이며 durable repo rule이나 source of truth가 아닙니다.
+
+`/tk:gap --review` compatibility run은 계속 `runs/gap/<GAP-ID>/report.md`와 `run.json`을 사용합니다. `/tk:review`는 이 compatibility artifact를 덮어쓰지 않습니다.
 
 ## `/tk:next` artifact policy
 

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -478,6 +478,86 @@ Abort code 목록:
 - `GITHUB_REQUIRED_UNAVAILABLE`
 - `VERIFICATION_UNAVAILABLE`
 
+
+## `/tk:review` Output Contract
+
+- 목적: frozen goal/spec 또는 sealed workflow 대비 launch 결과와 현재 구현을 검증하고 verdict를 남깁니다.
+- `/tk:gap --review`는 v7 Contract-based Gap Review compatibility mode이며, `/tk:review`는 post-launch verification command입니다.
+- 기본 target은 latest launch receipt가 참조하는 workflow이고, 없으면 latest GAP, handoff, 명시 path, 사용자 goal/spec 순서로 찾습니다.
+- 구현 수정, launch 실행, commit, push, PR, merge, release, deploy, GitHub issue write는 수행하지 않습니다.
+- verification 없이 `REVIEW_PASS`를 선언하지 않습니다.
+
+기본 receipt 위치:
+
+```text
+.claude/tigerkit/branches/<branch-key>/review/RVW-YYYYMMDD-HHmmss-RAND.md
+.claude/tigerkit/branches/<branch-key>/review/current.md
+```
+
+Machine-readable block:
+
+```tigerkit-review-report
+version: 1
+review_id: RVW-YYYYMMDD-HHmmss-RAND
+scope_kind: git_branch | git_detached | git_no_remote | workspace
+scope_key: <branch-key-or-workspace-key>
+status: REVIEW_PASS | REVIEW_PARTIAL | REVIEW_FAIL | REVIEW_BLOCKED
+verdict: Pass | Partial | Fail | Blocked
+target:
+  source: workflow | launch | handoff | user | path | none
+  ref: <path#section or none>
+requirements_checked: []
+verification:
+  passed: []
+  failed: []
+  blocked: []
+closed_gaps: []
+remaining_gaps: []
+drift_risks: []
+next_action: <one sentence or 없음>
+```
+
+기본 stdout:
+
+```text
+✅ Review 완료: <RVW-ID>
+브랜치 범위: <branch-key>
+결과: REVIEW_PASS | REVIEW_PARTIAL | REVIEW_FAIL | REVIEW_BLOCKED
+Verdict: Pass | Partial | Fail | Blocked
+대상: <workflow|launch|handoff|user|path|none>:<ref>
+
+검증: <passed>/<total> 통과, <failed> 실패, <blocked> 차단
+닫힌 gap: <count>
+남은 gap: <count>
+Drift/Risk: <none|count>
+
+보고서: .claude/tigerkit/branches/<branch-key>/review/<RVW-ID>.md
+최신본: .claude/tigerkit/branches/<branch-key>/review/current.md
+
+다음 행동: <없음|/tk:gap 재실행|/tk:launch 재실행|human decision 필요|/tk:handoff>
+```
+
+상태 기호:
+
+- `✅` = `REVIEW_PASS`
+- `⚠️` = `REVIEW_PARTIAL`
+- `🛑` = `REVIEW_FAIL` 또는 `REVIEW_BLOCKED`
+
+`/tk:review` report 필수 H2:
+
+```md
+# Review Report: <RVW-ID>
+
+## 요약
+## Review Target
+## Verification Evidence
+## Closed Gaps
+## Remaining Gaps
+## Drift / Risk
+## Verdict
+## Next Recommendation
+```
+
 ## `/tk:next` Output Contract
 
 - 목적: 현재 TigerKit artifact와 workspace/repo context를 읽고 다음 안전 실행 항목 하나를 실제로 이어서 시도합니다.

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -1,6 +1,6 @@
 # TigerKit 운영 사용법
 
-이 문서는 TigerKit v8.0 사용 가이드입니다. 산출물 위치는 `.tigerkit/docs/artifact-layout.md`, 출력 규칙은 `.tigerkit/docs/output-contract.md`를 기준으로 봅니다.
+이 문서는 TigerKit 현재 command surface 사용 가이드입니다. 산출물 위치는 `.tigerkit/docs/artifact-layout.md`, 출력 규칙은 `.tigerkit/docs/output-contract.md`를 기준으로 봅니다.
 
 ## 언어
 
@@ -11,14 +11,14 @@
 ## 핵심 모델
 
 ```text
-TigerKit = branch-scoped source intake + sealed gap workflow + human-approved launch + steering replacement next + durable reflection + continuation handoff + generalized meta-feedback
+TigerKit = branch-scoped source intake + sealed gap workflow + human-approved launch + review verdict + steering replacement next + durable reflection + continuation handoff + generalized meta-feedback
 ```
 
 TigerKit은 branch/workspace-local working memory와 durable repo insight를 분리합니다.
 
 - 사용자 입력, 문서, 스크린샷, 회의 메모, 이전 계획은 source material이며 그 자체로 authority가 아닙니다.
 - `gap` 산출물은 현재 branch 또는 plain workspace scope의 working memory입니다.
-- 기존 branch-local Spec Patch가 있으면 `/tk:gap`이 source material로 읽을 수 있지만, v8 MVP는 `/tk:spec` command를 노출하지 않습니다.
+- 기존 branch-local Spec Patch가 있으면 `/tk:gap`이 source material로 읽을 수 있지만, 현재 command surface는 `/tk:spec` command를 노출하지 않습니다.
 - 해당 산출물은 repo-wide durable knowledge가 아닙니다.
 - repo에 영구적으로 남길 insight는 `reflect`만 추출하고 `CLAUDE.md` 또는 `.claude/rules/**/*.md`에 반영합니다.
 - 다음 세션을 위한 사람이 읽는 continuation과 pending follow-up queue는 `handoff`가 담당합니다.
@@ -26,7 +26,7 @@ TigerKit은 branch/workspace-local working memory와 durable repo insight를 분
 
 ## Workspace fallback mode
 
-TigerKit은 GitHub repo 전용 도구가 아닙니다. 아래 context에서도 `/tk:gap`, `/tk:launch`, `/tk:reflect`가 동작해야 합니다.
+TigerKit은 GitHub repo 전용 도구가 아닙니다. 아래 context에서도 `/tk:gap`, `/tk:launch`, `/tk:review`, `/tk:reflect`가 동작해야 합니다.
 
 - GitHub remote가 없는 git repo
 - git 자체가 없는 plain workspace
@@ -44,15 +44,16 @@ TigerKit은 GitHub repo 전용 도구가 아닙니다. 아래 context에서도 `
 
 ## Command Surface
 
-Plugin namespace는 `/tk:*`입니다. TigerKit v8.0 MVP의 공개 실행 표면은 Claude Code plugin command이며, 별도 repo-local skill 파일 없이 `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다. 해당 workflow를 명시한 자연어 요청은 대응하는 `/tk:*` command contract로 처리합니다.
+Plugin namespace는 `/tk:*`입니다. TigerKit 현재 공개 실행 표면은 Claude Code plugin command이며, 별도 repo-local skill 파일 없이 `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다. 해당 workflow를 명시한 자연어 요청은 대응하는 `/tk:*` command contract로 처리합니다.
 
-Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 포함하지 않습니다. Hermes에서 native `/gap`, `/launch`, `/reflect` command를 제공하려면 Hermes plugin(`.hermes/plugins/<name>/plugin.yaml`, `ctx.register_command`)이 필요하므로, 사전조사 후 별도 adapter 작업으로 다룹니다.
+Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 현재 release artifact에 포함하지 않습니다. Hermes에서 native `/gap`, `/launch`, `/review`, `/reflect` command를 제공하려면 Hermes plugin(`.hermes/plugins/<name>/plugin.yaml`, `ctx.register_command`)이 필요하므로, 사전조사 후 별도 adapter 작업으로 다룹니다.
 
 | Command | 역할 | 저장 성격 |
 | --- | --- | --- |
 | `/tk:gap` | 사용자 입력, 문서, 스크린샷, 회의 메모, 기존 branch-local Spec Patch를 source material로 intake하고, source grounding, ambiguity attack, sealed launch workflow 생성을 수행한 뒤 `GAP_READY` 또는 `GAP_BLOCKED`로 끝납니다. | branch-local |
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 사용자가 고칠 finding과 답할 clarification을 남깁니다. | branch-local |
 | `/tk:launch` | sealed workflow만 `tk-runner` subagent로 실행하고 verification, abort receipt, runtime harness, reflect trace를 남깁니다. git/GitHub/commit은 capability로 기록하고 필요 없으면 skip reason으로 성공할 수 있습니다. | branch/workspace-local execution |
+| `/tk:review` | frozen goal/spec 또는 sealed workflow 대비 launch 결과와 현재 구현을 검증하고 `REVIEW_PASS`, `REVIEW_PARTIAL`, `REVIEW_FAIL`, `REVIEW_BLOCKED` verdict를 남깁니다. | branch/workspace-local review |
 | `/tk:reflect` | gap+launch trace와 branch-local 산출물에서 repo에 남길 insight만 추출하고 반영합니다. | durable insight |
 | `/tk:next` | current state와 TigerKit artifact를 읽어 다음 안전 실행 항목 하나를 실제로 이어서 시도하며 receipt를 남깁니다. | branch/workspace-local continuation execution |
 | `/tk:handoff` | 다음 세션이나 다음 작업자가 이어받을 수 있도록 continuation 문서를 작성합니다. | continuation |
@@ -70,6 +71,8 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 /tk:launch
 /tk:launch --no-worktree
 /tk:launch --autopilot
+/tk:review
+/tk:review --latest
 /tk:reflect
 /tk:reflect --dry-run
 /tk:reflect --no-meta-feedback
@@ -145,6 +148,17 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 - workflow가 worktree context 적용을 required precondition으로 두었는데 승인/evidence가 없으면 `WORKTREE_CONTEXT_APPROVAL_REQUIRED`로 task 실행 전 abort합니다.
 - `/tk:launch`는 `tk-runner` runtime harness를 receipt에 기록합니다. Claude Code 배포 agent는 `model: sonnet`이며, unavailable/fallback 상태를 숨기지 않습니다.
 - commit은 preflight receipt에 `user_preapproved_commit=true`와 `approval_source_ref`가 있을 때만 가능합니다.
+
+
+### `/tk:review`
+
+- `/tk:review`는 GAP → Launch 이후 frozen goal/spec 또는 sealed workflow에 맞게 구현 결과를 검증합니다.
+- `/tk:gap --review`는 v7 Contract-based Gap Review compatibility mode이며, `/tk:review`는 post-launch verification command입니다.
+- 기본 입력은 latest launch receipt가 참조하는 workflow이고, 없으면 latest GAP, handoff, 명시 path, 사용자 goal/spec 순서로 target을 찾습니다.
+- 구현을 수정하거나 launch를 대신 실행하지 않습니다. read-only 검증과 generated review report 작성만 수행합니다.
+- 결과는 `REVIEW_PASS`, `REVIEW_PARTIAL`, `REVIEW_FAIL`, `REVIEW_BLOCKED` 중 하나입니다.
+- report는 `.claude/tigerkit/branches/<branch-key>/review/` 아래에 저장하고 closed gaps, remaining gaps, drift/risk, next recommendation을 분리합니다.
+- `REVIEW_PASS`는 diff 존재나 launch 성공 문자열만으로 선언하지 않고, frozen target의 required requirement와 verification evidence를 현재 관측값으로 확인해야 합니다.
 
 ### Maintainer only: `--maintainer-proof`
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # TigerKit
 
-TigerKit(`tk`, plugin namespace `/tk:*`)은 sealed GAP → Launch → Reflect 흐름과 steering replacement `/tk:next`, continuation handoff, generalized meta-feedback으로 AI-induced source loss를 줄입니다. GitHub PR/commit은 선택 capability이며, plain workspace에서도 workflow 작성·실행·회고가 가능해야 합니다.
+TigerKit(`tk`, plugin namespace `/tk:*`)은 sealed GAP → Launch → Review → Reflect 흐름과 steering replacement `/tk:next`, continuation handoff, generalized meta-feedback으로 AI-induced source loss를 줄입니다. GitHub PR/commit은 선택 capability이며, plain workspace에서도 workflow 작성·실행·회고가 가능해야 합니다.
 
 공개 실행 표면은 Claude Code plugin command입니다. 별도 repo-local skill 파일 없이 `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다.
 
-v8 MVP scope는 Claude Code command 기능 안정화입니다. Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 사전조사 대상이지만 현재 release artifact로 제공하지 않습니다. 특히 Hermes에서 `/gap`, `/launch`, `/reflect` 같은 native slash command를 제공하려면 `.hermes/plugins/<name>/plugin.yaml`과 `ctx.register_command()` 기반 plugin adapter가 별도로 필요하며, 이 PR 범위에는 포함하지 않습니다.
+현재 release scope는 Claude Code command 기능 안정화입니다. Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 사전조사 대상이지만 현재 release artifact로 제공하지 않습니다. 특히 Hermes에서 `/gap`, `/launch`, `/review`, `/reflect` 같은 native slash command를 제공하려면 `.hermes/plugins/<name>/plugin.yaml`과 `ctx.register_command()` 기반 plugin adapter가 별도로 필요하며, 이 PR 범위에는 포함하지 않습니다.
 
 해당 workflow를 명시한 natural language request는 대응하는 `/tk:*` command contract로 처리합니다.
 
@@ -30,7 +30,7 @@ claude plugin details tk
 claude plugin install tk@tiger-kit --scope project
 ```
 
-설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:next`, `/tk:handoff`, `/tk:meta-feedback` 명령을 사용합니다. v8 MVP에서 source intake와 spec normalization은 `/tk:gap`이 담당하므로 `/tk:spec`은 공개 command surface에서 제거되었습니다.
+설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:launch`, `/tk:review`, `/tk:reflect`, `/tk:next`, `/tk:handoff`, `/tk:meta-feedback` 명령을 사용합니다. 현재 command surface에서 source intake와 spec normalization은 `/tk:gap`이 담당하므로 `/tk:spec`은 공개 command surface에서 제거되었습니다.
 
 ## Command Surface
 
@@ -39,6 +39,7 @@ claude plugin install tk@tiger-kit --scope project
 | `/tk:gap` | 즉석 지시, 브레인스토밍, 회의 메모, URL, ticket, 기존 branch-local Spec Patch를 source material로 intake하고, source를 ground하고 ambiguity를 attack한 뒤 launch 가능한 sealed workflow를 만들거나 `GAP_BLOCKED`로 중단합니다. | branch-local |
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 조치 필요 항목과 확인 필요 항목를 `report.md`와 `run.json`에 남깁니다. | branch-local |
 | `/tk:launch` | sealed workflow만 `tk-runner` subagent로 실행하고 검증, 중단 receipt, runtime harness, reflect trace를 남깁니다. | branch-local execution |
+| `/tk:review` | frozen goal/spec 또는 sealed workflow 대비 launch 결과와 현재 구현을 검증해 `REVIEW_PASS`, `REVIEW_PARTIAL`, `REVIEW_FAIL`, `REVIEW_BLOCKED` verdict를 남깁니다. | branch-local review |
 | `/tk:reflect` | gap+launch trace와 branch-local working memory에서 repo에 영구 보존할 insight만 rubric으로 선별하고 durable target에 반영한 뒤 기본적으로 meta-feedback을 함께 제출합니다. | durable insight |
 | `/tk:next` | 현재 TigerKit 상태와 workspace/repo context를 읽고 다음 안전 실행 항목 하나를 실제로 이어서 시도하며 receipt를 남깁니다. | branch/workspace-local continuation execution |
 | `/tk:handoff` | 다음 세션이나 다음 작업자가 이어받을 continuation 문서와 pending follow-up queue를 작성합니다. | continuation |
@@ -49,13 +50,17 @@ claude plugin install tk@tiger-kit --scope project
 ```text
 gap = source intake + source grounding + ambiguity attack + sealed launch workflow 생성
 launch = sealed workflow 실행 + verification + abort/reflect receipt
-reflect = gap+launch trace와 branch-local working memory에서 repo에 영구 보존할 insight만 추출/반영
+review = frozen goal/spec 대비 구현 결과 검증 + Pass/Partial/Fail/Blocked verdict
+reflect = gap+launch+review trace와 branch-local working memory에서 repo에 영구 보존할 insight만 추출/반영
 next = continuation state를 읽고 다음 안전 작업을 실제로 이어서 시도
 handoff = 다음 세션/작업자용 continuation context
 meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
 ```
 
-`gap`과 canonical `handoff` 산출물은 `.claude/tigerkit/branches/<branch-key>/` 아래의 branch-local generated working memory입니다. 기존 branch-local Spec Patch가 있으면 `/tk:gap`의 source material로 읽을 수 있지만, v8 MVP는 `/tk:spec` command를 노출하지 않습니다. `/tk:handoff`는 경로 미지정 resume을 위해 `.claude/tigerkit/global-index.json`에 최신 handoff pointer도 기록합니다. repo-wide durable knowledge가 아닙니다.
+`gap`, `review`, canonical `handoff` 산출물은 `.claude/tigerkit/branches/<branch-key>/` 아래의 branch-local generated working memory입니다. 기존 branch-local Spec Patch가 있으면 `/tk:gap`의 source material로 읽을 수 있지만, 현재 command surface는 `/tk:spec` command를 노출하지 않습니다. `/tk:handoff`는 경로 미지정 resume을 위해 `.claude/tigerkit/global-index.json`에 최신 handoff pointer도 기록합니다. repo-wide durable knowledge가 아닙니다.
+
+
+`/tk:review`는 review/correction loop를 TigerKit 용어로 흡수한 post-launch 검증 command입니다. 별도 브랜드나 별도 command surface를 추가하지 않고, frozen target 대비 닫힌 gap, 남은 gap, drift/risk, 다음 loop 결정을 기록합니다.
 
 `/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY` 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 task별 `assumed_preconditions`, 봉인 전 `readonly_preflight` 결과, sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source/preflight failure 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,203 @@
+---
+description: frozen goal/spec과 launch 결과를 대조해 통과·부분통과·실패 verdict와 다음 loop 결정을 생성합니다.
+argument-hint: "[review target|--latest] [--against <workflow|spec|handoff|path>] [--print-report]"
+---
+
+이 명령은 TigerKit vNext GAP → Launch → Review loop의 review contract를 따릅니다. `/tk:gap --review`는 v7 Contract-based Gap Review compatibility mode로 계속 유지하며, `/tk:review`는 launch 이후 구현 결과를 frozen goal/spec 또는 sealed workflow에 맞춰 검증하는 별도 command입니다.
+
+사용자에게는 한글로 답합니다. 코드, path, URL, ticket, commit, hash, identifier, error, contract field name은 원문 그대로 둘 수 있습니다.
+
+목표: `/tk:review`는 구현이 frozen goal/spec 또는 latest sealed workflow의 requirements와 verification gate를 실제로 만족했는지 확인하고, 남은 gap·drift·risk를 분리한 뒤 다음 결정을 제안합니다.
+
+```text
+review = compare frozen target + observed implementation + verification evidence -> Pass | Partial | Fail
+```
+
+## Command surface
+
+- plugin slash invocation은 `/tk:review`입니다.
+- `/tk:review`는 기본적으로 current branch scope의 최신 TigerKit artifact를 읽습니다.
+- 자연어로 “리뷰해줘”, “검증해줘”, “launch 결과 맞는지 봐줘”처럼 요청해도 이 contract를 따릅니다.
+- `/tk:review`는 새 요구사항을 만들거나 launch workflow를 실행하지 않습니다.
+- `/tk:gap --review`는 Product/Design Spec 대비 current implementation을 검사하는 v7 compatibility mode입니다. `/tk:review`는 GAP → Launch 이후의 frozen target verification입니다.
+
+## Inputs to inspect
+
+가능한 범위에서 아래를 읽습니다.
+
+- current worktree/workspace root
+- current branch key 또는 workspace scope key
+- `.claude/tigerkit/global-index.json`
+- `.claude/tigerkit/branches/<branch-key>/branch-state.json`
+- latest GAP workflow/status: `.claude/tigerkit/branches/<branch-key>/gap/current.md`
+- latest launch receipt: `.claude/tigerkit/branches/<branch-key>/launch/current.md`
+- explicit `--against` target 또는 명시 path
+- latest handoff/current.md에 남은 frozen goal 또는 pending verification
+- current git status/diff when git is available
+- user-provided review target/context
+
+Missing artifacts are not fatal by themselves. Treat them as review scope evidence or `REVIEW_BLOCKED` reason.
+
+## Review target resolution
+
+우선순위:
+
+1. 명시 `--against <path>` 또는 command argument의 repo-local path
+2. latest launch receipt가 참조하는 `workflow_path`
+3. latest GAP `gap/current.md`의 sealed `tigerkit-launch-workflow`
+4. latest handoff의 `Mission`, `Key Decisions`, `Pending Work`, `Validation`
+5. 사용자 메시지의 explicit goal/spec
+
+위 항목이 모두 없으면 `REVIEW_BLOCKED`로 끝내고 필요한 source를 짧게 적습니다.
+
+## Comparison policy
+
+Review는 source와 관측값을 분리합니다.
+
+```text
+Evidence = directly observed
+Interpretation = inferred from evidence
+Decision = confirmed by user or source contract
+Suggestion = proposed, not confirmed
+```
+
+검증 절차:
+
+1. frozen target의 confirmed requirements, non-goals, verification gates를 추출합니다.
+2. latest launch receipt가 있으면 task 결과, failed gate, abort code, commit status, reflect trace를 읽습니다.
+3. current implementation은 파일, diff, rendered output, command output 등 관측 가능한 evidence로만 평가합니다.
+4. claimed closed gap은 해당 requirement와 verification evidence를 모두 대조합니다.
+5. scope drift는 workflow/goal 밖 변경, non-goal 침범, 새로운 user-facing surface를 기준으로 분리합니다.
+6. 새 source decision이 필요하면 추측하지 않고 `REVIEW_BLOCKED` 또는 `REVIEW_PARTIAL`로 남깁니다.
+
+## Verdict rules
+
+`/tk:review`는 정확히 하나의 최종 상태로 끝납니다.
+
+```text
+REVIEW_PASS
+- frozen target의 required requirements와 verification gates가 통과했고, blocking drift가 없습니다.
+
+REVIEW_PARTIAL
+- 일부 gap은 닫혔지만 remaining gap, failed optional verification, 또는 non-blocking drift가 있습니다.
+
+REVIEW_FAIL
+- required requirement, required verification gate, safety rule, 또는 non-goal이 실패했습니다.
+
+REVIEW_BLOCKED
+- 검증에 필요한 frozen target, implementation evidence, command capability, 또는 human decision이 없습니다.
+```
+
+사용자-facing verdict label은 `Pass`, `Partial`, `Fail`, `Blocked`를 유지할 수 있지만 주변 설명은 한글로 씁니다.
+
+## Safety rules
+
+`/tk:review` must not:
+
+- implementation을 수정합니다.
+- `/tk:launch`를 대신 실행합니다.
+- sealed workflow가 필요한 구현을 `/tk:gap → /tk:launch` 없이 우회합니다.
+- missing requirement를 임의 해석합니다.
+- 새 backlog를 confirmed requirement로 승격합니다.
+- verification 없이 `REVIEW_PASS`를 선언합니다.
+- commit, push, PR, merge, release, deploy, GitHub issue write 같은 외부 side effect를 수행합니다.
+- `/tk:gap --review` compatibility artifact를 `/tk:review` artifact처럼 덮어씁니다.
+
+`/tk:review` may:
+
+- repo/workspace 파일과 generated TigerKit artifacts를 읽습니다.
+- read-only verification command를 실행합니다.
+- `.claude/tigerkit/branches/<branch-key>/review/` 아래에 generated review report를 작성합니다.
+- `.claude/tigerkit/global-index.json`과 `branch-state.json`에 latest review pointer를 기록합니다.
+- next action으로 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:handoff`, 또는 human decision을 추천합니다.
+
+## Artifact policy
+
+기본 receipt 위치:
+
+```text
+.claude/tigerkit/branches/<branch-key>/review/RVW-YYYYMMDD-HHmmss-RAND.md
+.claude/tigerkit/branches/<branch-key>/review/current.md
+```
+
+Plain workspace fallback도 같은 `branches/<scope-key>/review/` layout을 사용하고 receipt에 `범위 종류: workspace`를 표시합니다.
+
+Review report는 generated branch-local working memory입니다. durable repo rule이나 source of truth가 아닙니다.
+
+## Report content
+
+`review/current.md`는 사람용 H2와 machine-readable block을 함께 포함합니다.
+
+````md
+# Review Report: <RVW-ID>
+
+## 요약
+## Review Target
+## Verification Evidence
+## Closed Gaps
+## Remaining Gaps
+## Drift / Risk
+## Verdict
+## Next Recommendation
+
+```tigerkit-review-report
+version: 1
+review_id: RVW-YYYYMMDD-HHmmss-RAND
+scope_kind: git_branch | git_detached | git_no_remote | workspace
+scope_key: <branch-key-or-workspace-key>
+status: REVIEW_PASS | REVIEW_PARTIAL | REVIEW_FAIL | REVIEW_BLOCKED
+verdict: Pass | Partial | Fail | Blocked
+target:
+  source: workflow | launch | handoff | user | path | none
+  ref: <path#section or none>
+requirements_checked: []
+verification:
+  passed: []
+  failed: []
+  blocked: []
+closed_gaps: []
+remaining_gaps: []
+drift_risks: []
+next_action: <one sentence or 없음>
+```
+````
+
+## 기본 stdout
+
+```text
+✅ Review 완료: <RVW-ID>
+브랜치 범위: <branch-key>
+결과: REVIEW_PASS | REVIEW_PARTIAL | REVIEW_FAIL | REVIEW_BLOCKED
+Verdict: Pass | Partial | Fail | Blocked
+대상: <workflow|launch|handoff|user|path|none>:<ref>
+
+검증: <passed>/<total> 통과, <failed> 실패, <blocked> 차단
+닫힌 gap: <count>
+남은 gap: <count>
+Drift/Risk: <none|count>
+
+보고서: .claude/tigerkit/branches/<branch-key>/review/<RVW-ID>.md
+최신본: .claude/tigerkit/branches/<branch-key>/review/current.md
+
+다음 행동: <없음|/tk:gap 재실행|/tk:launch 재실행|human decision 필요|/tk:handoff>
+```
+
+상태 기호:
+
+- `✅` = `REVIEW_PASS`
+- `⚠️` = `REVIEW_PARTIAL`
+- `🛑` = `REVIEW_FAIL` 또는 `REVIEW_BLOCKED`
+
+## 다음 행동 추천
+
+- `REVIEW_PASS`: 구현을 받아들이거나 `/tk:reflect`로 durable insight 후보를 정리합니다.
+- `REVIEW_PARTIAL`: remaining gap이 작고 source가 충분하면 `/tk:gap`으로 새 sealed workflow를 만듭니다.
+- `REVIEW_FAIL`: 실패한 verification gate나 non-goal 침범을 먼저 수정할 수 있도록 `/tk:gap` 재실행 또는 abort handoff를 추천합니다.
+- `REVIEW_BLOCKED`: missing frozen target, missing source, unavailable verification, 또는 human decision을 먼저 요청합니다.
+
+## 금지
+
+- `REVIEW_PASS`를 단순 diff 존재나 launch receipt의 성공 문자열만으로 선언하지 않습니다.
+- `/tk:gap --review`의 finding table을 `/tk:review` verdict로 혼동하지 않습니다.
+- 별도 브랜드나 별도 command surface를 추가하지 않습니다.
+- `freeze`를 사용자-facing command로 노출하지 않습니다. Freeze는 frozen target/assumption을 가리키는 내부 review 개념입니다.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,10 +1,11 @@
 {
-  "skill_name": "tiger-kit-v8-sealed-gap-launch-reflect",
+  "skill_name": "tiger-kit-vNext-sealed-gap-launch-review-reflect",
   "command_surface": {
-    "surface_model": "TigerKit v8.0 MVP exposes Claude Code plugin commands only; commands/*.md and .claude-plugin/plugin.json own /tk:* contracts without separate repo-local skill or non-Claude adapter files.",
+    "surface_model": "TigerKit vNext exposes Claude Code plugin commands only; commands/*.md and .claude-plugin/plugin.json own /tk:* contracts without separate repo-local skill or non-Claude adapter files.",
     "core_commands": [
       "/tk:gap",
       "/tk:launch",
+      "/tk:review",
       "/tk:reflect"
     ],
     "compatibility_commands": [
@@ -44,7 +45,7 @@
     ],
     "plugin_version_policy": "Authoritative version is .claude-plugin/plugin.json; evals must not hard-code a concrete version literal.",
     "utility_commands": [],
-    "workspace_fallback": "GitHub, git, and commit are capabilities, not prerequisites; plain workspace scope uses workspace-<slug>--<hash>.",
+    "workspace_fallback": "GitHub, git, and commit are capabilities, not prerequisites; plain workspace scope uses workspace-<slug>--<hash>; /tk:review can verify from generated artifacts or explicit user targets.",
     "continuation_commands": [
       "/tk:next"
     ]
@@ -52,18 +53,20 @@
   "evals": [
     {
       "id": 0,
-      "name": "command-surface-v8-gap-launch-reflect-next-without-spec",
-      "prompt": "Evaluate TigerKit v8 active command surface. Do not write files.",
-      "expected_output": "Should list /tk:gap, /tk:launch, and /tk:reflect as the primary v8 flow. Should list /tk:next as a steering replacement continuation command that can attempt the next safe work item and write a receipt, while preserving /tk:gap --review, /tk:handoff, and /tk:meta-feedback as compatibility or secondary commands. Should explain that /tk:spec is not exposed in the v8 MVP command surface because source intake is owned by /tk:gap. Should explain that commands/*.md plus .claude-plugin/plugin.json own the /tk:* contracts and that Hermes/Codex/npx-skills command adapters are out of MVP scope with no adapter files shipped.",
+      "name": "command-surface-vNext-gap-launch-review-reflect-next-without-spec",
+      "prompt": "Evaluate TigerKit active command surface. Do not write files.",
+      "expected_output": "Should list /tk:gap, /tk:launch, /tk:review, and /tk:reflect as the primary TigerKit flow. Should list /tk:next as a steering replacement continuation command that can attempt the next safe work item and write a receipt, while preserving /tk:gap --review, /tk:handoff, and /tk:meta-feedback as compatibility or secondary commands. Should explain that /tk:review is post-launch frozen-target verification and /tk:gap --review is v7 Contract-based Gap Review compatibility. Should explain that /tk:spec is not exposed in the active command surface because source intake is owned by /tk:gap. Should explain that commands/*.md plus .claude-plugin/plugin.json own the /tk:* contracts and that Hermes/Codex/npx-skills command adapters are out of MVP scope with no adapter files shipped.",
       "files": [
         ".claude-plugin/plugin.json",
         "README.md",
-        ".tigerkit/docs/usage.md"
+        ".tigerkit/docs/usage.md",
+        "commands/review.md"
       ],
       "expectations": [
         "Lists /tk:gap",
         "Lists /tk:launch",
         "Lists /tk:reflect",
+        "Lists /tk:review",
         "Does not expose /tk:spec",
         "Preserves /tk:handoff",
         "Preserves /tk:meta-feedback",
@@ -72,7 +75,8 @@
         "States Hermes adapter is out of MVP scope",
         "States Codex adapter is out of MVP scope",
         "Ships no non-Claude adapter files",
-        "Lists /tk:next as steering replacement continuation command"
+        "Lists /tk:next as steering replacement continuation command",
+        "Distinguishes /tk:review from /tk:gap --review compatibility"
       ]
     },
     {
@@ -288,12 +292,13 @@
     },
     {
       "id": 12,
-      "name": "plugin-version-and-command-manifest-v8",
-      "prompt": "Evaluate marketplace plugin metadata for TigerKit v8. Do not write files.",
-      "expected_output": "Should treat .claude-plugin/plugin.json as the authoritative version source, verify its version is valid semver without hard-coding a concrete version literal in eval expectations, and provide a bump script that defaults to origin/main:.claude-plugin/plugin.json as the baseline so stale local branches do not reuse old versions. Should include ./commands/launch.md and ./commands/next.md, preserve /tk:gap, /tk:reflect, /tk:handoff, and /tk:meta-feedback command entries, and not include ./commands/spec.md because v8 source intake is owned by /tk:gap.",
+      "name": "plugin-version-and-command-manifest-vNext",
+      "prompt": "Evaluate marketplace plugin metadata for TigerKit current command surface. Do not write files.",
+      "expected_output": "Should treat .claude-plugin/plugin.json as the authoritative version source, verify its version is valid semver without hard-coding a concrete version literal in eval expectations, and provide a bump script that defaults to origin/main:.claude-plugin/plugin.json as the baseline so stale local branches do not reuse old versions. Should include ./commands/launch.md, ./commands/review.md, and ./commands/next.md, preserve /tk:gap, /tk:reflect, /tk:handoff, and /tk:meta-feedback command entries, and not include ./commands/spec.md because current source intake is owned by /tk:gap.",
       "files": [
         ".claude-plugin/plugin.json",
         "commands/launch.md",
+        "commands/review.md",
         "commands/next.md",
         "scripts/check-plugin-version.py",
         "scripts/bump-plugin-version.py"
@@ -303,6 +308,7 @@
         "No concrete version literal in eval expectations",
         "Includes ./commands/launch.md",
         "Includes ./commands/next.md",
+        "Includes ./commands/review.md",
         "Does not include ./commands/spec.md",
         "Preserves gap command",
         "Preserves reflect command",
@@ -474,10 +480,11 @@
       "id": 21,
       "name": "user-facing-output-labels-are-korean",
       "prompt": "Evaluate TigerKit user-facing stdout/report templates. Do not write files.",
-      "expected_output": "Should keep machine-readable status codes and contract field names intact, while rendering user-facing labels in Korean across /tk:gap, /tk:launch, /tk:next, /tk:reflect, /tk:handoff, /tk:meta-feedback, and tk-runner receipts. Examples include 브랜치 범위, 워크플로, 검증 게이트, 실행 하네스, 선택한 작업, 변경 파일, 승인, 차단 사유, 추가 근거 필요, 사용자 메모리 후보, 메타 피드백, 비식별화 기록, 일반화 게이트, and 다음 행동.",
+      "expected_output": "Should keep machine-readable status codes and contract field names intact, while rendering user-facing labels in Korean across /tk:gap, /tk:launch, /tk:review, /tk:next, /tk:reflect, /tk:handoff, /tk:meta-feedback, and tk-runner receipts. Examples include 브랜치 범위, 워크플로, 검증 게이트, 실행 하네스, 선택한 작업, 변경 파일, 승인, 차단 사유, 추가 근거 필요, 사용자 메모리 후보, 메타 피드백, 비식별화 기록, 일반화 게이트, and 다음 행동.",
       "files": [
         "commands/gap.md",
         "commands/launch.md",
+        "commands/review.md",
         "commands/next.md",
         "commands/reflect.md",
         "commands/handoff.md",
@@ -494,7 +501,37 @@
         "Uses Korean stdout label 선택한 작업",
         "Uses Korean stdout label 추가 근거 필요",
         "Uses Korean meta-feedback section 비식별화 기록",
-        "Uses Korean next action label 다음 행동"
+        "Uses Korean next action label 다음 행동",
+        "Uses Korean stdout label 닫힌 gap",
+        "Uses Korean stdout label 남은 gap"
+      ]
+    },
+    {
+      "id": 22,
+      "name": "review-verifies-frozen-target-after-launch",
+      "prompt": "Evaluate /tk:review after a launch has produced implementation evidence. Do not write source files.",
+      "expected_output": "Should resolve a frozen review target from explicit --against, latest launch workflow, latest GAP, handoff, or user-provided goal/spec; compare confirmed requirements and verification evidence against current implementation; report closed gaps, remaining gaps, drift/risk, and exactly one verdict: REVIEW_PASS, REVIEW_PARTIAL, REVIEW_FAIL, or REVIEW_BLOCKED. Should not modify implementation, execute /tk:launch, create commits, create PRs, or confuse /tk:review with /tk:gap --review compatibility.",
+      "files": [
+        "commands/review.md",
+        ".claude-plugin/plugin.json",
+        "README.md",
+        ".tigerkit/docs/usage.md",
+        ".tigerkit/docs/output-contract.md",
+        ".tigerkit/docs/artifact-layout.md"
+      ],
+      "expectations": [
+        "Plugin manifest includes ./commands/review.md",
+        "Resolves explicit and latest review targets",
+        "Checks confirmed requirements",
+        "Checks verification evidence",
+        "Reports closed gaps",
+        "Reports remaining gaps",
+        "Reports drift/risk",
+        "Uses REVIEW_PASS REVIEW_PARTIAL REVIEW_FAIL REVIEW_BLOCKED",
+        "Does not mutate implementation",
+        "Does not execute launch",
+        "Does not commit or open PR",
+        "Distinguishes /tk:review from /tk:gap --review"
       ]
     }
   ]


### PR DESCRIPTION
## 요약
- 이슈: #106 — `tk:gap` 중심 loop에 post-launch 검증 단계를 흡수하고 별도 브랜드/command surface를 만들지 않는 방향 정리
- 수정: 새 `/tk:review` command contract를 추가하고 plugin manifest, README, usage, artifact layout, output contract, eval fixture를 동기화
- 검증: plugin manifest/repo validation, JSON 문법 검증, version invariant, diff whitespace, `/tk:review` surface regression check 통과

## 변경 내용
- `commands/review.md`를 추가해 frozen goal/spec 또는 sealed workflow 대비 구현 검증 contract를 정의했습니다.
- `/tk:review` 결과를 `REVIEW_PASS`, `REVIEW_PARTIAL`, `REVIEW_FAIL`, `REVIEW_BLOCKED`로 고정하고 closed gaps / remaining gaps / drift-risk / next recommendation을 분리했습니다.
- `/tk:gap --review`는 v7 Contract-based Gap Review compatibility mode로 유지하고, `/tk:review`는 post-launch verification command로 분리했습니다.
- plugin/marketplace manifest에 `./commands/review.md`와 `review verdict` surface를 추가했습니다.
- 새 공개 command surface에 맞춰 plugin version을 `10.0.0`으로 major bump했습니다.
- README, usage, artifact layout, output contract, eval fixture를 `/tk:review` 기준으로 동기화했습니다.

## 검증
```text
PASS manifest contains commands/review.md
PASS commands/review.md exists
PASS README mentions /tk:review
PASS usage mentions /tk:review
PASS output contract mentions /tk:review
PASS artifact layout has review path
PASS evals mention review command
PASS no Telltale branding in tracked user docs

claude plugin validate .claude-plugin/plugin.json
- Validation passed with warnings
- warning: root CLAUDE.md at the plugin root is not loaded as project context

claude plugin validate .
- Validation passed

python3 -m json.tool evals/evals.json >/dev/null
- OK

python3 scripts/check-plugin-version.py
- plugin version ok: 10.0.0

git diff --check
- OK
```

Closes #106
