### PR TITLE
fix: address feedback issue #106

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "tk",
-  "description": "sealed GAP workflow, human-approved launch, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "9.0.1",
+  "description": "sealed GAP workflow, human-approved launch, goal/spec review, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
+  "version": "10.0.0",
   "author": {
     "name": "MTGVim"
   },
   "commands": [
     "./commands/gap.md",
+    "./commands/review.md",
     "./commands/launch.md",
     "./commands/reflect.md",
     "./commands/next.md",

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -83,8 +83,8 @@ MVP에서는 path compatibility를 위해 `branches/` 아래에 저장하지만 
 | `.claude/tigerkit/branches/<branch-key>/launch/current.md` | launch status, task/gate 결과, abort code, commit decision을 보존하는 최소 run record입니다. | branch-local execution |
 | `.claude/tigerkit/branches/<branch-key>/reflect/<RFL-ID>.md` | `/tk:reflect` generated report archive입니다. `tigerkit-reflect-report` block을 포함합니다. durable apply가 아닙니다. | branch-local generated |
 | `.claude/tigerkit/branches/<branch-key>/reflect/current.md` | 최신 reflect report copy입니다. | branch-local pointer |
-| `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md` | `/tk:gap --review` 사용자가 읽는 compatibility gap report 본문입니다. Actionable Findings, Clarification Needed, next action 중심입니다. | branch-local |
-| `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/run.json` | `/tk:gap --review` 후속 대화와 기계 처리를 위한 최소 run record입니다. user-facing short Ref와 canonical ID mapping을 보존합니다. | branch-local |
+| `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md` | `/tk:gap --review`와 `/tk:review` 사용자가 읽는 review report 본문입니다. Actionable Findings, Clarification Needed, verdict, next action 중심입니다. | branch-local |
+| `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/run.json` | `/tk:gap --review`와 `/tk:review` 후속 대화와 기계 처리를 위한 최소 run record입니다. user-facing short Ref와 canonical ID mapping을 보존합니다. | branch-local |
 | `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/maintainer-proof/` | `--maintainer-proof`가 명시된 경우에만 생성하는 self-eval/performance proof, gate/debug metadata, baseline snapshot 영역입니다. | branch-local maintainer-only |
 | `.claude/tigerkit/branches/<branch-key>/handoffs/current.md` | `/tk:handoff`가 생성하는 canonical continuation 문서. 최신 경로는 `global-index.json`과 `branch-state.json`에 pointer로 기록합니다. 현재 작업을 방해하면 안 되는 follow-up은 `Pending Backlog` 섹션에 source/evidence/priority/blocked-by/next action과 함께 보관할 수 있습니다. | branch-local continuation |
 | `.claude/tigerkit/branches/<branch-key>/handoffs/YYYY-MM-DD-task-name.md` | `archive=true` 또는 명시적 archive 요청 때만 생성하는 branch-local continuation archive. | branch-local continuation |
@@ -108,7 +108,7 @@ MVP에서는 path compatibility를 위해 `branches/` 아래에 저장하지만 
 
 `GAP_READY` archive는 사람용 report와 정확히 하나의 `tigerkit-gap-status` block, 정확히 하나의 `tigerkit-launch-workflow` block을 포함합니다. `GAP_BLOCKED` report는 `tigerkit-gap-status` block만 포함하고 `tigerkit-launch-workflow` block을 포함하지 않습니다.
 
-`/tk:gap --review` compatibility mode만 v7 review layout을 씁니다.
+`/tk:gap --review` compatibility mode와 `/tk:review`는 같은 branch-local review layout을 씁니다.
 
 ```text
 .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -314,7 +314,58 @@ Rejected finding uses one of:
 - `missing_producer_evidence`
 - `superseded_source`
 
-### `/tk:gap --maintainer-proof` Output Contract
+### `/tk:review` Output Contract
+
+이 section은 `/tk:review` stdout의 authoritative contract입니다. `/tk:review`는 `/tk:gap --review`와 같은 Contract-based review engine과 branch-local review layout을 사용하되, frozen goal/spec 대비 implementation 검증을 사용자-facing command로 제공합니다.
+
+- 목적: implementation이 frozen goal/spec를 만족하는지, claimed gap이 닫혔는지, regression이나 scope drift가 있는지 검증합니다.
+- 기본 저장 위치: `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/`
+- 기본 산출물은 `report.md`와 `run.json`입니다.
+- verdict는 `Pass`, `Partial`, `Fail` 중 하나입니다.
+- next recommendation은 `accept`, `run another gap loop`, `escalate to human`, `abort or re-scope` 중 하나입니다.
+- sealed launch workflow는 생성하지 않습니다.
+- `freeze`와 `launch`는 internal workflow concept이며 별도 `/tk:freeze` command는 노출하지 않습니다.
+- final finding, source conflict, clarification, rejected summary 규칙은 `/tk:gap --review`와 같습니다.
+
+### `/tk:review default stdout`
+
+```text
+Review 완료: <GAP-ID>
+브랜치 범위: <branch-key>
+Verdict: <Pass|Partial|Fail>
+결과: P0 <count> / P1 <count> / P2 <count> / 근거 충돌 <count> / 확인 필요 <count>
+보고서: .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md
+실행 JSON: .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/run.json
+다음 행동: <accept|run another gap loop|escalate to human|abort or re-scope>
+```
+
+### `/tk:review report.md` H2
+
+```md
+# Review: <GAP-ID>
+
+## Verdict
+
+## 사용한 근거
+
+## What Changed
+
+## Closed Gaps
+
+## Remaining Gaps
+
+## Drift / Risk
+
+## 조치 필요 항목
+
+## 확인 필요
+
+## 미채택 요약
+
+## Next Recommendation
+```
+
+## `/tk:gap --maintainer-proof` Output Contract
 
 `--maintainer-proof`를 명시한 경우에만 self-eval/performance proof와 내부 gate/debug metadata를 생성하거나 claim할 수 있습니다.
 

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -11,7 +11,7 @@
 ## 핵심 모델
 
 ```text
-TigerKit = branch-scoped source intake + sealed gap workflow + human-approved launch + steering replacement next + durable reflection + continuation handoff + generalized meta-feedback
+TigerKit = branch-scoped source intake + sealed gap workflow + human-approved launch + goal/spec review + steering replacement next + durable reflection + continuation handoff + generalized meta-feedback
 ```
 
 TigerKit은 branch/workspace-local working memory와 durable repo insight를 분리합니다.
@@ -26,7 +26,7 @@ TigerKit은 branch/workspace-local working memory와 durable repo insight를 분
 
 ## Workspace fallback mode
 
-TigerKit은 GitHub repo 전용 도구가 아닙니다. 아래 context에서도 `/tk:gap`, `/tk:launch`, `/tk:reflect`가 동작해야 합니다.
+TigerKit은 GitHub repo 전용 도구가 아닙니다. 아래 context에서도 `/tk:gap`, `/tk:launch`, `/tk:review`, `/tk:reflect`가 동작해야 합니다.
 
 - GitHub remote가 없는 git repo
 - git 자체가 없는 plain workspace
@@ -52,6 +52,7 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 | --- | --- | --- |
 | `/tk:gap` | 사용자 입력, 문서, 스크린샷, 회의 메모, 기존 branch-local Spec Patch를 source material로 intake하고, source grounding, ambiguity attack, sealed launch workflow 생성을 수행한 뒤 `GAP_READY` 또는 `GAP_BLOCKED`로 끝납니다. | branch-local |
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 사용자가 고칠 finding과 답할 clarification을 남깁니다. | branch-local |
+| `/tk:review` | frozen goal/spec 대비 implementation을 검증해 closed gaps, remaining gaps, drift/risk, Pass/Partial/Fail verdict, next recommendation을 남깁니다. `/tk:gap --review`와 같은 review engine을 사용합니다. | branch-local |
 | `/tk:launch` | sealed workflow만 `tk-runner` subagent로 실행하고 verification, abort receipt, runtime harness, reflect trace를 남깁니다. git/GitHub/commit은 capability로 기록하고 필요 없으면 skip reason으로 성공할 수 있습니다. | branch/workspace-local execution |
 | `/tk:reflect` | gap+launch trace와 branch-local 산출물에서 repo에 남길 insight만 추출하고 반영합니다. | durable insight |
 | `/tk:next` | current state와 TigerKit artifact를 읽어 다음 안전 실행 항목 하나를 실제로 이어서 시도하며 receipt를 남깁니다. | branch/workspace-local continuation execution |
@@ -70,6 +71,7 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 v8 MVP에 
 /tk:launch
 /tk:launch --no-worktree
 /tk:launch --autopilot
+/tk:review
 /tk:reflect
 /tk:reflect --dry-run
 /tk:reflect --no-meta-feedback
@@ -130,6 +132,18 @@ Report: .claude/tigerkit/branches/main--c0ffee/gap/GAP-20260617-143012-A7F3.md
 - P3/nit/duplicate/unverifiable/source_conflict는 final finding이 아닙니다.
 - `/tk:gap --review` run artifact는 `.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/` 아래에 저장합니다. 기본 `/tk:gap` sealed workflow는 `.claude/tigerkit/branches/<branch-key>/gap/` 아래에 저장합니다.
 - 유저향 compact table은 run-local short Ref(`G1`, `R1`, `C1`, `Q1`)를 우선 표시합니다.
+
+### `/tk:review`
+
+`/tk:review`는 `/tk:gap --review`와 같은 Contract-based review engine을 사용하는 직관적 진입점입니다.
+
+- frozen goal/spec, implementation plan, current implementation을 비교합니다.
+- claimed gap이 실제로 닫혔는지 확인합니다.
+- regression과 scope drift를 감지합니다.
+- `Pass`, `Partial`, `Fail` 중 하나의 verdict를 냅니다.
+- 다음 추천을 `accept`, `run another gap loop`, `escalate to human`, `abort or re-scope` 중 하나로 정리합니다.
+- 기본 산출물은 `/tk:gap --review`와 같은 `report.md`와 `run.json`입니다.
+- `freeze`와 `launch`를 새 user-facing command로 노출하지 않고, internal workflow concept로만 다룹니다.
 
 ### `/tk:launch`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TigerKit
 
-TigerKit(`tk`, plugin namespace `/tk:*`)은 sealed GAP → Launch → Reflect 흐름과 steering replacement `/tk:next`, continuation handoff, generalized meta-feedback으로 AI-induced source loss를 줄입니다. GitHub PR/commit은 선택 capability이며, plain workspace에서도 workflow 작성·실행·회고가 가능해야 합니다.
+TigerKit(`tk`, plugin namespace `/tk:*`)은 GAP → internal freeze → Launch → Review → Reflect 흐름과 steering replacement `/tk:next`, continuation handoff, generalized meta-feedback으로 AI-induced source loss를 줄입니다. GitHub PR/commit은 선택 capability이며, plain workspace에서도 workflow 작성·실행·검토·회고가 가능해야 합니다.
 
 공개 실행 표면은 Claude Code plugin command입니다. 별도 repo-local skill 파일 없이 `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다.
 
@@ -30,7 +30,7 @@ claude plugin details tk
 claude plugin install tk@tiger-kit --scope project
 ```
 
-설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:launch`, `/tk:reflect`, `/tk:next`, `/tk:handoff`, `/tk:meta-feedback` 명령을 사용합니다. v8 MVP에서 source intake와 spec normalization은 `/tk:gap`이 담당하므로 `/tk:spec`은 공개 command surface에서 제거되었습니다.
+설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:launch`, `/tk:review`, `/tk:reflect`, `/tk:next`, `/tk:handoff`, `/tk:meta-feedback` 명령을 사용합니다. v8 MVP에서 source intake와 spec normalization은 `/tk:gap`이 담당하므로 `/tk:spec`은 공개 command surface에서 제거되었습니다.
 
 ## Command Surface
 
@@ -38,6 +38,7 @@ claude plugin install tk@tiger-kit --scope project
 | --- | --- | --- |
 | `/tk:gap` | 즉석 지시, 브레인스토밍, 회의 메모, URL, ticket, 기존 branch-local Spec Patch를 source material로 intake하고, source를 ground하고 ambiguity를 attack한 뒤 launch 가능한 sealed workflow를 만들거나 `GAP_BLOCKED`로 중단합니다. | branch-local |
 | `/tk:gap --review` | v7 Contract-based Gap Review compatibility mode로 조치 필요 항목과 확인 필요 항목를 `report.md`와 `run.json`에 남깁니다. | branch-local |
+| `/tk:review` | frozen goal/spec 대비 implementation을 검증해 closed gaps, remaining gaps, drift/risk, verdict, next recommendation을 남깁니다. `/tk:gap --review`와 같은 review engine을 사용합니다. | branch-local |
 | `/tk:launch` | sealed workflow만 `tk-runner` subagent로 실행하고 검증, 중단 receipt, runtime harness, reflect trace를 남깁니다. | branch-local execution |
 | `/tk:reflect` | gap+launch trace와 branch-local working memory에서 repo에 영구 보존할 insight만 rubric으로 선별하고 durable target에 반영한 뒤 기본적으로 meta-feedback을 함께 제출합니다. | durable insight |
 | `/tk:next` | 현재 TigerKit 상태와 workspace/repo context를 읽고 다음 안전 실행 항목 하나를 실제로 이어서 시도하며 receipt를 남깁니다. | branch/workspace-local continuation execution |
@@ -48,8 +49,10 @@ claude plugin install tk@tiger-kit --scope project
 
 ```text
 gap = source intake + source grounding + ambiguity attack + sealed launch workflow 생성
+internal freeze = GAP_READY workflow와 hash로 목표/spec를 봉인
 launch = sealed workflow 실행 + verification + abort/reflect receipt
-reflect = gap+launch trace와 branch-local working memory에서 repo에 영구 보존할 insight만 추출/반영
+review = frozen goal/spec 대비 구현 검증 + closed/remaining gaps + drift/risk verdict
+reflect = gap+launch+review trace와 branch-local working memory에서 repo에 영구 보존할 insight만 추출/반영
 next = continuation state를 읽고 다음 안전 작업을 실제로 이어서 시도
 handoff = 다음 세션/작업자용 continuation context
 meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
@@ -57,7 +60,7 @@ meta-feedback = 세션 내 TigerKit 개선 피드백 일반화
 
 `gap`과 canonical `handoff` 산출물은 `.claude/tigerkit/branches/<branch-key>/` 아래의 branch-local generated working memory입니다. 기존 branch-local Spec Patch가 있으면 `/tk:gap`의 source material로 읽을 수 있지만, v8 MVP는 `/tk:spec` command를 노출하지 않습니다. `/tk:handoff`는 경로 미지정 resume을 위해 `.claude/tigerkit/global-index.json`에 최신 handoff pointer도 기록합니다. repo-wide durable knowledge가 아닙니다.
 
-`/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY` 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 task별 `assumed_preconditions`, 봉인 전 `readonly_preflight` 결과, sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source/preflight failure 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
+`/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY` 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 task별 `assumed_preconditions`, 봉인 전 `readonly_preflight` 결과, sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source/preflight failure 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지하며, `/tk:review`는 같은 review engine을 frozen goal/spec 검증용 직관적 진입점으로 제공합니다.
 
 GitHub remote, git branch, commit 가능 여부는 launch preflight capability로 기록하며 prerequisite가 아닙니다. commit/PR이 불가능해도 workflow가 commit/PR을 요구하지 않으면 `/tk:launch`는 `Commit: skipped_not_git_repo` 같은 명시 skip reason으로 성공할 수 있습니다. Git worktree context는 Superpowers-style `SessionStart` read-only hook이 세션 시작 시 한 번 점검하고, base/source worktree에만 있는 root-level Markdown과 `.claude/` 후보를 `additionalContext`로 proposal-only 제안합니다. `/tk:gap`은 이 context를 source grounding에 포함하고, `/tk:launch`와 `/tk:next`는 command마다 같은 후보를 다시 묻지 않습니다. 사용자가 거절한 동일 candidate signature는 `.claude/tigerkit/local/session-start/worktree-context-declines.json`로 suppress합니다.
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,129 @@
+---
+description: frozen goal/spec과 current implementation을 비교해 closed gaps, remaining gaps, drift, next recommendation을 검증합니다.
+argument-hint: "[goal/spec refs or implementation target...] [--analysis-depth <direct|bounded|expanded|exhaustive-capped>] [--spec <SP-ID|path>] [--no-specs] [--print-report] [--maintainer-proof]"
+---
+
+이 명령은 TigerKit review command contract를 따릅니다. `/tk:review`는 `/tk:gap --review`와 같은 Contract-based review engine을 사용하는 사용자-facing 진입점입니다.
+
+사용자에게는 한글로 답합니다. 코드, path, URL, ticket, commit, hash, identifier, error, contract field name은 원문 그대로 둘 수 있습니다.
+
+목표: `/tk:review`는 frozen goal/spec, implementation plan, current implementation을 비교해 gap이 실제로 닫혔는지, regression이나 scope drift가 생겼는지, 다음 행동이 accept/re-run/escalate/abort 중 무엇인지 판단합니다.
+
+```text
+review = compare implementation against frozen goal/spec + verify closed gaps + detect drift + recommend next action
+```
+
+## Command surface
+
+- plugin slash invocation은 `/tk:review`입니다.
+- `/tk:review`는 `/tk:gap --review` compatibility behavior와 같은 review contract를 사용합니다.
+- `/tk:review`는 sealed launch workflow를 생성하지 않습니다.
+- `/tk:review`는 implementation을 수정하지 않습니다.
+- `/tk:review`는 `freeze` 또는 `launch`를 새 user-facing command로 노출하지 않습니다.
+- `--maintainer-proof`는 maintainer/self-eval 전용입니다. 일반 사용자 품질 모드나 더 강한 review 옵션처럼 설명하지 않습니다.
+- `--lite`와 `--strict`가 전달되면 compatibility flag로만 기록하고 user-facing quality mode로 쓰지 않습니다.
+
+## Inputs
+
+입력 source는 아래를 사용할 수 있습니다.
+
+- user-provided goal/spec text
+- issue, URL, ticket, docs, screenshot/export, meeting note
+- active confirmed branch-local Spec Patch
+- implementation plan
+- current implementation target hints
+- prior `/tk:gap` or `/tk:launch` artifacts
+
+Frozen goal/spec이 없거나 current implementation target을 확인할 수 없으면 추측하지 않고 `확인 필요` 또는 `미채택 요약`으로 남깁니다.
+
+## Review behavior
+
+1. current workspace root, branch-key, user-provided refs, target hints, current implementation candidates, integration freshness metadata를 bind합니다.
+2. Product/Design/Design System/Engineering/QA/Analytics source를 Contract로 normalize합니다.
+3. confirmed, non-superseded contract set을 freeze합니다.
+4. implementation plan이 있으면 PlanCoverageAgent가 plan gap candidate만 생성합니다.
+5. current implementation이 있으면 ImplementationComplianceAgent가 implementation gap candidate만 생성합니다.
+6. 모든 candidate는 Candidate Intake Gate를 통과해야 합니다.
+7. CriticalRedTeamAgent는 would-be accepted 또는 high-risk gated candidate가 있을 때 targeted verification으로 최대 1회만 실행합니다.
+8. JudgeMergerAgent만 final finding, rejected observation, source conflict, clarification을 확정합니다.
+9. closed gaps, remaining gaps, drift/risk, next recommendation을 report에 정리합니다.
+
+## Verdict
+
+`/tk:review`는 아래 verdict 중 하나를 출력합니다.
+
+| Verdict | 의미 |
+| --- | --- |
+| `Pass` | confirmed goal/spec 기준으로 remaining actionable gap이나 blocking clarification이 없습니다. |
+| `Partial` | 일부 gap은 닫혔지만 remaining gap 또는 reference-only clarification이 있습니다. |
+| `Fail` | 핵심 gap이 닫히지 않았거나 regression, scope drift, blocking clarification이 있습니다. |
+
+Verdict는 JudgeMergerAgent 결과, clarification 상태, regression/drift evidence에만 근거합니다. 내부 의도, 이전 성공, proxy 판단으로 completion을 주장하지 않습니다.
+
+## Output and artifacts
+
+`/tk:review` 기본 산출물은 `/tk:gap --review`와 같은 branch-local review layout을 사용합니다.
+
+```text
+.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md
+.claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/run.json
+```
+
+기본 stdout은 compact receipt입니다.
+
+```text
+Review 완료: <GAP-ID>
+브랜치 범위: <branch-key>
+Verdict: <Pass|Partial|Fail>
+결과: P0 <count> / P1 <count> / P2 <count> / 근거 충돌 <count> / 확인 필요 <count>
+보고서: .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/report.md
+실행 JSON: .claude/tigerkit/branches/<branch-key>/runs/gap/<GAP-ID>/run.json
+다음 행동: <accept|run another gap loop|escalate to human|abort or re-scope>
+```
+
+Report H2는 `/tk:gap --review` H2에 review sections를 더해 아래 순서를 사용합니다.
+
+```md
+# Review: <GAP-ID>
+
+## Verdict
+
+## 사용한 근거
+
+## What Changed
+
+## Closed Gaps
+
+## Remaining Gaps
+
+## Drift / Risk
+
+## 조치 필요 항목
+
+## 확인 필요
+
+## 미채택 요약
+
+## Next Recommendation
+```
+
+## Safety and evidence rules
+
+- basis를 절대적 진실처럼 단정하지 않습니다.
+- source conflict를 임의 병합하지 않습니다.
+- subagent candidate를 final finding처럼 출력하지 않습니다.
+- P3/nit, duplicate, unverifiable, source_conflict는 final finding으로 출력하지 않습니다.
+- producer-absence claim에는 producer-side evidence가 필요합니다.
+- candidate의 file:line, module-path, rendered output evidence는 JudgeMergerAgent queue 진입 전에 현재 target surface에서 read-back으로 재확인합니다.
+- visible UI copy는 confirmed contract와 exact match가 필요합니다.
+- finding이 0개가 될 때까지 반복하지 않습니다.
+- 사용자가 고치거나 답할 수 없는 proof/debug/self-eval metadata는 기본 stdout에 출력하지 않습니다.
+
+## 다음 추천 action mapping
+
+| 조건 | 추천 |
+| --- | --- |
+| `Pass`이고 blocking item 없음 | `accept` |
+| `Partial`이고 remaining gap이 작고 source가 충분함 | `run another gap loop` |
+| 사용자/owner 결정이 필요함 | `escalate to human` |
+| source conflict, scope drift, 핵심 requirement 불일치가 큼 | `abort or re-scope` |

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -9,6 +9,7 @@
     ],
     "compatibility_commands": [
       "/tk:gap --review",
+      "/tk:review",
       "/tk:handoff",
       "/tk:meta-feedback"
     ],
@@ -54,7 +55,7 @@
       "id": 0,
       "name": "command-surface-v8-gap-launch-reflect-next-without-spec",
       "prompt": "Evaluate TigerKit v8 active command surface. Do not write files.",
-      "expected_output": "Should list /tk:gap, /tk:launch, and /tk:reflect as the primary v8 flow. Should list /tk:next as a steering replacement continuation command that can attempt the next safe work item and write a receipt, while preserving /tk:gap --review, /tk:handoff, and /tk:meta-feedback as compatibility or secondary commands. Should explain that /tk:spec is not exposed in the v8 MVP command surface because source intake is owned by /tk:gap. Should explain that commands/*.md plus .claude-plugin/plugin.json own the /tk:* contracts and that Hermes/Codex/npx-skills command adapters are out of MVP scope with no adapter files shipped.",
+      "expected_output": "Should list /tk:gap, /tk:launch, and /tk:reflect as the primary v8 flow. Should list /tk:review as the goal/spec review entrypoint and /tk:next as a steering replacement continuation command that can attempt the next safe work item and write a receipt, while preserving /tk:gap --review, /tk:handoff, and /tk:meta-feedback as compatibility or secondary commands. Should explain that /tk:spec is not exposed in the v8 MVP command surface because source intake is owned by /tk:gap. Should explain that commands/*.md plus .claude-plugin/plugin.json own the /tk:* contracts and that Hermes/Codex/npx-skills command adapters are out of MVP scope with no adapter files shipped.",
       "files": [
         ".claude-plugin/plugin.json",
         "README.md",
@@ -65,6 +66,7 @@
         "Lists /tk:launch",
         "Lists /tk:reflect",
         "Does not expose /tk:spec",
+        "Preserves /tk:review",
         "Preserves /tk:handoff",
         "Preserves /tk:meta-feedback",
         "Mentions /tk:gap --review compatibility",
@@ -127,6 +129,7 @@
       "expected_output": "Should preserve v7 Contract-based Gap Review behavior: compare Product/Design Spec, implementation plan, and current implementation; emit report.md and run.json; use JudgeMergerAgent for final findings; keep P0/P1/P2 accepted findings only; keep default stdout compact. Should not describe --review as a stronger quality mode.",
       "files": [
         "commands/gap.md",
+        "commands/review.md",
         ".claude/rules/review/gap-analysis.md",
         ".tigerkit/docs/output-contract.md"
       ],
@@ -141,6 +144,32 @@
     },
     {
       "id": 4,
+      "name": "review-verifies-implementation-against-goal-spec",
+      "prompt": "Evaluate /tk:review behavior. Do not write files.",
+      "expected_output": "Should verify implementation against a frozen goal/spec, check whether claimed gaps are closed, detect regressions and scope drift, produce a Pass/Partial/Fail verdict, and recommend accept, run another gap loop, escalate to human, or abort/re-scope. Should use the same Contract-based review engine and branch-local report.md/run.json layout as /tk:gap --review. Should not expose freeze or launch as standalone commands.",
+      "files": [
+        "commands/review.md",
+        "commands/gap.md",
+        ".tigerkit/docs/output-contract.md",
+        ".tigerkit/docs/usage.md",
+        "README.md"
+      ],
+      "expectations": [
+        "Uses /tk:review command",
+        "Verifies implementation against frozen goal/spec",
+        "Checks closed gaps",
+        "Detects regressions",
+        "Detects scope drift",
+        "Produces Pass Partial Fail verdict",
+        "Recommends accept run another gap loop escalate to human abort or re-scope",
+        "Uses report.md and run.json layout",
+        "Reuses /tk:gap --review engine",
+        "Does not expose /tk:freeze",
+        "Does not expose /tk:launch as new concept beyond existing command"
+      ]
+    },
+    {
+      "id": 5,
       "name": "launch-missing-workflow-aborts",
       "prompt": "Evaluate /tk:launch when no workflow path or current workflow exists. Do not write files.",
       "expected_output": "Should abort before execution with WORKFLOW_NOT_FOUND. Should not invent a workflow, ask mid-flight questions, or run tasks. Should emit an aborted launch receipt with report and reflect trace paths when possible.",
@@ -157,7 +186,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "name": "launch-multiple-workflow-blocks-aborts",
       "prompt": "Evaluate /tk:launch when the workflow file contains two tigerkit-launch-workflow blocks. Do not write files.",
       "expected_output": "Should abort before execution with MULTIPLE_WORKFLOW_BLOCKS. Should require exactly one launch workflow block and should not pick one silently.",
@@ -172,7 +201,7 @@
       ]
     },
     {
-      "id": 6,
+      "id": 7,
       "name": "launch-hash-mismatch-aborts",
       "prompt": "Evaluate /tk:launch when workflow_sha256 does not match the fenced block body. Do not write files.",
       "expected_output": "Should calculate SHA-256 from the raw UTF-8 bytes inside the single tigerkit-launch-workflow fenced block after LF normalization and exactly one final LF, excluding fence lines and without YAML sorting. Should abort with WORKFLOW_HASH_MISMATCH when the calculated hash differs.",
@@ -190,7 +219,7 @@
       ]
     },
     {
-      "id": 7,
+      "id": 8,
       "name": "launch-human-decision-required-no-question",
       "prompt": "Evaluate /tk:launch when execution reveals a new product or API decision is required. Do not write files.",
       "expected_output": "Should not ask the user a mid-flight question. Should abort with HUMAN_DECISION_REQUIRED, preserve completed task count, failed precondition, failed gate or reason, and next action for human decision or workflow regeneration. The launch trace should structure the abort fact as reusable gap input.",
@@ -208,7 +237,7 @@
       ]
     },
     {
-      "id": 8,
+      "id": 9,
       "name": "launch-autopilot-disabled-in-phase1",
       "prompt": "Evaluate /tk:launch --autopilot in Phase 1. Do not write files.",
       "expected_output": "Should not perform bounded recovery in Phase 1. If workflow autopilot_policy.enabled is false, abort with AUTOPILOT_DISABLED. If recovery is requested by the command surface but unavailable in Phase 1, abort with AUTOPILOT_NOT_IMPLEMENTED_IN_PHASE1. Should not change requirements or expand scope.",
@@ -224,7 +253,7 @@
       ]
     },
     {
-      "id": 9,
+      "id": 10,
       "name": "launch-out-of-scope-diff-aborts",
       "prompt": "Evaluate /tk:launch when completing a task would require files or behavior outside the sealed workflow scope. Do not write files.",
       "expected_output": "Should abort with OUT_OF_SCOPE_DIFF rather than broadening scope. Should not commit out-of-scope changes and should report the blocked reason in the launch receipt.",
@@ -240,7 +269,7 @@
       ]
     },
     {
-      "id": 10,
+      "id": 11,
       "name": "reflect-after-launch-no-durable-apply-without-approval",
       "prompt": "Evaluate reflect behavior after /tk:launch completes or aborts. Do not write files.",
       "expected_output": "Should allow /tk:launch to write generated reflect trace artifacts at reflect/<RFL-ID>.md and reflect/current.md for /tk:reflect. Should not apply durable CLAUDE.md or .claude/rules changes or create commits unless preflight approval recorded that action. Should classify repo durable insight, skill proposal, TigerKit meta-feedback, verification gap, workflow weakness, and unresolved follow-up separately.",
@@ -258,7 +287,7 @@
       ]
     },
     {
-      "id": 11,
+      "id": 12,
       "name": "session-start-worktree-context-proposal-read-only",
       "prompt": "Evaluate SessionStart worktree context proposal when a base worktree has root Markdown files and .claude/ that are missing in the current linked worktree. Do not write source files.",
       "expected_output": "Should register a SessionStart read-only hook that injects TIGERKIT_SESSION_START additional context with candidate signature, source/base worktree, base-only root-level Markdown candidates, base-only .claude/ candidate, safety contract, and decline marker path. It must not create symlinks, copy files, overwrite regular files, mutate source_worktree, or hydrate context automatically. /tk:gap should consume this context during source grounding. /tk:launch and /tk:next should consume the session context or matching decline marker instead of re-asking per command.",
@@ -287,13 +316,14 @@
       ]
     },
     {
-      "id": 12,
+      "id": 13,
       "name": "plugin-version-and-command-manifest-v8",
       "prompt": "Evaluate marketplace plugin metadata for TigerKit v8. Do not write files.",
       "expected_output": "Should treat .claude-plugin/plugin.json as the authoritative version source, verify its version is valid semver without hard-coding a concrete version literal in eval expectations, and provide a bump script that defaults to origin/main:.claude-plugin/plugin.json as the baseline so stale local branches do not reuse old versions. Should include ./commands/launch.md and ./commands/next.md, preserve /tk:gap, /tk:reflect, /tk:handoff, and /tk:meta-feedback command entries, and not include ./commands/spec.md because v8 source intake is owned by /tk:gap.",
       "files": [
         ".claude-plugin/plugin.json",
         "commands/launch.md",
+        "commands/review.md",
         "commands/next.md",
         "scripts/check-plugin-version.py",
         "scripts/bump-plugin-version.py"
@@ -302,6 +332,7 @@
         "Plugin version is valid semver",
         "No concrete version literal in eval expectations",
         "Includes ./commands/launch.md",
+        "Includes ./commands/review.md",
         "Includes ./commands/next.md",
         "Does not include ./commands/spec.md",
         "Preserves gap command",
@@ -314,7 +345,7 @@
       ]
     },
     {
-      "id": 13,
+      "id": 14,
       "name": "next-command-attempts-continuation-with-approval-gates",
       "prompt": "Evaluate /tk:next when latest handoff or launch/reflect trace contains a safe next work item. Do not create commits or PRs.",
       "expected_output": "Should inspect current TigerKit artifacts and any TIGERKIT_SESSION_START worktree context proposal, select one safe executable next item, attempt it within existing command contracts, and write a NEXT_DONE, NEXT_PARTIAL, NEXT_BLOCKED, or NEXT_SKIPPED receipt. Should not be stdout-only or recommendation-only. Should not execute /tk:launch, commit, PR, merge, release, deploy, GitHub issue writes, re-ask the same worktree candidate signature, or apply worktree context symlink/copy without explicit approval.",
@@ -338,7 +369,7 @@
       ]
     },
     {
-      "id": 14,
+      "id": 15,
       "name": "workspace-gap-ready-without-git",
       "prompt": "Evaluate /tk:gap in a plain folder with no .git when enough source exists. Do not write files.",
       "expected_output": "Should not fail merely because git rev-parse fails. Should use scope_kind=workspace, compute a stable workspace scope_key, write under .claude/tigerkit/branches/<scope-key>/ when writable, and produce GAP_READY with workspace_context when launchable. If artifacts are not writable, should block with ARTIFACT_ROOT_UNWRITABLE rather than pretending success.",
@@ -357,7 +388,7 @@
       ]
     },
     {
-      "id": 15,
+      "id": 16,
       "name": "workspace-launch-success-skips-commit",
       "prompt": "Evaluate /tk:launch for a GAP_READY workflow in a non-git workspace where verification passes and commit is not required. Do not write files.",
       "expected_output": "Should execute the sealed workflow, pass verification, report SUCCESS, and record 커밋: skipped_not_git_repo. Missing git/GitHub must not abort unless commit or PR is required by the workflow.",
@@ -375,7 +406,7 @@
       ]
     },
     {
-      "id": 16,
+      "id": 17,
       "name": "reflect-fallback-user-memory-proposal",
       "prompt": "Evaluate /tk:reflect in a non-git workspace without CLAUDE.md or .claude/rules. Do not write files.",
       "expected_output": "Should not create repo durable rule files by default. Should produce generated reflect report when possible and include 사용자 메모리 후보 or explicitly say none. Candidates are proposal-only and 자동 적용 false unless a host adapter and user approval support memory writes.",
@@ -393,7 +424,7 @@
       ]
     },
     {
-      "id": 17,
+      "id": 18,
       "name": "non-code-workflow-task-and-verification-types",
       "prompt": "Evaluate sealed workflow schema for non-code work such as docs/research/runbook generation. Do not write files.",
       "expected_output": "Should allow task_type values such as docs_change, research, file_generation, data_cleanup, ops_runbook, communication_draft, analysis, and manual_receipt. Verification gates may use file_exists, file_contains, artifact_written, link_checked, schema_valid, manual_review_required, or receipt_only; code tests are not mandatory.",
@@ -409,7 +440,7 @@
       ]
     },
     {
-      "id": 18,
+      "id": 19,
       "name": "launch-runtime-harness-uses-tk-runner-sonnet",
       "prompt": "Evaluate /tk:launch runtime harness before executing a sealed workflow. Do not write source files.",
       "expected_output": "Should dispatch execution through the tk-runner Claude Code agent when subagents are available, record expected_model sonnet, model_tier balanced, effort_tier medium, and runtime_harness status in the launch receipt. If required subagent/model harness is unavailable and inline fallback is not explicitly allowed, launch must abort before task execution with MODEL_HARNESS_UNAVAILABLE rather than silently running on the wrong model.",
@@ -429,7 +460,7 @@
       ]
     },
     {
-      "id": 19,
+      "id": 20,
       "name": "gap-preflights-launch-preconditions-before-sealing",
       "prompt": "Evaluate default /tk:gap for a workflow whose task depends on a static target relation or verification tool assumption that can be checked read-only before mutation. Do not write files.",
       "expected_output": "Should record task-level assumed_preconditions as checkable predicates, run static/read-only preflight before sealing, and only emit GAP_READY when required predicates pass. If a predicate fails or is unverifiable, should emit GAP_BLOCKED without tigerkit-launch-workflow. If a prior /tk:launch trace aborted with HUMAN_DECISION_REQUIRED or VERIFICATION_FAILED, should treat the structured abort fact as gap input so the same fact is not rediscovered during launch.",
@@ -450,7 +481,7 @@
       ]
     },
     {
-      "id": 20,
+      "id": 21,
       "name": "meta-feedback-generalization-gate",
       "prompt": "Evaluate /tk:meta-feedback when session feedback contains command friction mixed with repo-specific or domain-specific terms. Do not write files.",
       "expected_output": "Should run a pre-emit Domain-term guard, rewrite or reject proposals that contain host-specific nouns such as project/framework names, paths, symbols, domain entities, tickets, branches, PRs, commits, or URLs, and apply a Restate test asking whether the proposal still works in another repo and domain. Should route repo/domain insight to /tk:reflect, basis-target comparison to /tk:gap, follow-up storage to /tk:handoff, and only command or skill contract friction to /tk:meta-feedback. Output should use only the target command or skill contract vocabulary and feedback taxonomy, and the 비식별화 기록 should report 일반화 게이트 and 재진술 테스트 status.",
@@ -471,7 +502,7 @@
       ]
     },
     {
-      "id": 21,
+      "id": 22,
       "name": "user-facing-output-labels-are-korean",
       "prompt": "Evaluate TigerKit user-facing stdout/report templates. Do not write files.",
       "expected_output": "Should keep machine-readable status codes and contract field names intact, while rendering user-facing labels in Korean across /tk:gap, /tk:launch, /tk:next, /tk:reflect, /tk:handoff, /tk:meta-feedback, and tk-runner receipts. Examples include 브랜치 범위, 워크플로, 검증 게이트, 실행 하네스, 선택한 작업, 변경 파일, 승인, 차단 사유, 추가 근거 필요, 사용자 메모리 후보, 메타 피드백, 비식별화 기록, 일반화 게이트, and 다음 행동.",


### PR DESCRIPTION
## 요약
- 이슈: #106 Improve: Revive `tk:gap` and absorb the Telltale loop into tiger-kit
- 수정: .claude-plugin/plugin.json, .tigerkit/docs/artifact-layout.md, .tigerkit/docs/output-contract.md 등 7개 파일
- 검증: 4개 로컬 검증 통과

## 검증 결과
- `claude plugin validate .claude-plugin/plugin.json`: PASS
- `claude plugin validate .`: PASS
- `python3 -m json.tool evals/evals.json`: PASS
- `git diff --check`: PASS

Closes #106