### PR TITLE
fix: address feedback issue #113

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "sealed GAP workflow, human-approved launch, review verdict, durable reflection, steering replacement continuation, meta-feedback, and handoff를 통해 AI-induced source loss를 줄이는 repo-local TigerKit Claude Code 플러그인입니다.",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -30,8 +30,9 @@ v8 MVP는 `/tk:spec` command를 공개하지 않습니다. 기존 `.claude/tiger
 이 section은 v8.0 기본 `/tk:gap` stdout의 authoritative contract입니다. `/tk:gap --review` compatibility stdout은 아래 `/tk:gap --review` section을 따릅니다.
 
 - 목적: source를 ground하고 ambiguity를 attack한 뒤 launch 가능한 sealed workflow를 만들거나 launch 금지 사유를 기록합니다.
-- `/tk:gap`은 반드시 `GAP_READY` 또는 `GAP_BLOCKED` 중 하나로 끝납니다.
-- `GAP_READY`는 정확히 하나의 `tigerkit-launch-workflow` block을 포함해야 합니다.
+- `/tk:gap`은 반드시 `GAP_READY`, `GAP_AUTO_LAUNCHED`, 또는 `GAP_BLOCKED` 중 하나로 끝납니다.
+- `GAP_READY`는 정확히 하나의 `tigerkit-launch-workflow` block을 포함하고 실행은 `/tk:launch`로 분리해야 합니다.
+- `GAP_AUTO_LAUNCHED`는 같은 `/tk:gap` 호출 안에서 sealed workflow 생성 뒤 정식 `/tk:launch` 루틴까지 완료 또는 중단한 경우에만 사용합니다.
 - `GAP_BLOCKED`는 `tigerkit-launch-workflow` block을 포함하면 안 됩니다.
 - 기본 workflow archive 위치: `.claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md`
 - 최신 workflow pointer copy: `.claude/tigerkit/branches/<branch-key>/gap/current.md`
@@ -52,6 +53,20 @@ GAP_READY: <WF-ID>
 다음 행동: /tk:launch
 ```
 
+`GAP_AUTO_LAUNCHED` stdout:
+
+```text
+GAP_AUTO_LAUNCHED: <WF-ID>
+브랜치 범위: <branch-key>
+워크플로: .claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md
+워크플로 해시: <sha256>
+Launch 결과: SUCCESS | PARTIAL | ABORTED
+Launch 보고서: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md
+검증: <passed>/<total> 통과, <failed> 실패, <blocked> 차단
+커밋: <created|skipped_preflight_required|skipped_not_requested|skipped_not_git_repo|skipped_no_github_remote|skipped_readonly_workspace|skipped_commit_policy_skip>
+다음 행동: <없음|사용자 결정 필요|검증 실패 수정|review finding 반영|commit 승인 필요>
+```
+
 `GAP_BLOCKED` stdout:
 
 ```text
@@ -67,10 +82,12 @@ GAP_BLOCKED: <GAP-ID>
 ### `tigerkit-gap-status` block
 
 ```tigerkit-gap-status
-status: GAP_READY | GAP_BLOCKED
+status: GAP_READY | GAP_AUTO_LAUNCHED | GAP_BLOCKED
 workflow_id: WF-YYYYMMDD-HHmmss-RAND | null
 workflow_path: .claude/tigerkit/branches/<branch-key>/gap/<WF-ID>.md | null
 workflow_sha256: <sha256> | null
+launch_receipt_path: .claude/tigerkit/branches/<branch-key>/launch/<LCH-ID>.md | null
+launch_status: SUCCESS | PARTIAL | ABORTED | null
 blocked_reasons: []
 human_decisions: []
 missing_sources: []

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -91,7 +91,8 @@ Hermes Agent, Codex CLI, `npx skills` 기반 command-skill adapter는 현재 rel
 - ambiguity attack으로 contradiction, missing decision, hidden dependency, task precondition, edge case, failure mode, verification gap을 찾습니다.
 - 각 task의 `assumed_preconditions`를 checkable predicate로 기록하고, verification gate 중 static/read-only 부분은 봉인 전 preflight로 1회 확인합니다.
 - 이전 `/tk:launch`가 `HUMAN_DECISION_REQUIRED` 또는 `VERIFICATION_FAILED`로 멈춘 trace가 있으면 다음 `/tk:gap` 입력으로 구조화해 같은 사실을 재발견하지 않습니다.
-- launch 가능한 sealed workflow가 있으면 `GAP_READY`로 끝내고 `tigerkit-launch-workflow` block을 생성합니다.
+- launch 가능한 sealed workflow가 있으면 기본적으로 `GAP_READY`로 끝내고 `tigerkit-launch-workflow` block을 생성한 뒤 다음 행동을 `/tk:launch`로 둡니다.
+- 같은 `/tk:gap` 호출 안에서 host 자동화가 정식 `/tk:launch` 루틴까지 이어서 수행한 경우에는 `GAP_READY`가 아니라 `GAP_AUTO_LAUNCHED`로 끝내고 workflow와 launch receipt를 함께 기록합니다.
 - unresolved decision/conflict/missing source 때문에 launch하면 안 되면 `GAP_BLOCKED`로 끝내고 workflow block을 생성하지 않습니다.
 - `/tk:gap --review`는 v7 Contract-based Gap Review compatibility mode입니다.
 - `--analysis-depth <direct|bounded|expanded|exhaustive-capped>`는 source discovery depth만 명시하며 품질 gate를 낮추지 않습니다.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ meta-feedback = TigerKit-level workflow/tooling friction만 조건부 일반화
 
 `/tk:review`는 review/correction loop를 TigerKit 용어로 흡수한 post-launch 검증 command입니다. 별도 브랜드나 별도 command surface를 추가하지 않고, frozen target 대비 닫힌 gap, 남은 gap, drift/risk, 다음 loop 결정을 기록합니다.
 
-`/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY` 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 task별 `assumed_preconditions`, 봉인 전 `readonly_preflight` 결과, sealed `tigerkit-launch-workflow`가 포함되어야 하고, `GAP_BLOCKED`에는 unresolved decision/conflict/missing source/preflight failure 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
+`/tk:gap` 기본 실행은 git/GitHub가 없는 workspace에서도 `GAP_READY`, `GAP_AUTO_LAUNCHED`, 또는 `GAP_BLOCKED`로 끝날 수 있습니다. `GAP_READY`에는 task별 `assumed_preconditions`, 봉인 전 `readonly_preflight` 결과, sealed `tigerkit-launch-workflow`가 포함되어야 하고 실행은 `/tk:launch`로 분리됩니다. 같은 `/tk:gap` 호출 안에서 정식 launch 루틴까지 수행한 경우에는 `GAP_AUTO_LAUNCHED`로 workflow와 launch receipt를 함께 보고해야 합니다. `GAP_BLOCKED`에는 unresolved decision/conflict/missing source/preflight failure 때문에 workflow block을 포함하지 않습니다. v7 review behavior는 `/tk:gap --review`에서 유지합니다.
 
 GitHub remote, git branch, commit 가능 여부는 launch preflight capability로 기록하며 prerequisite가 아닙니다. commit/PR이 불가능해도 workflow가 commit/PR을 요구하지 않으면 `/tk:launch`는 `Commit: skipped_not_git_repo` 같은 명시 skip reason으로 성공할 수 있습니다. Git worktree context는 Superpowers-style `SessionStart` read-only hook이 세션 시작 시 한 번 점검하고, base/source worktree에만 있는 root-level Markdown과 `.claude/` 후보를 `additionalContext`로 proposal-only 제안합니다. `/tk:gap`은 이 context를 source grounding에 포함하고, `/tk:launch`와 `/tk:next`는 command마다 같은 후보를 다시 묻지 않습니다. 사용자가 거절한 동일 candidate signature는 `.claude/tigerkit/local/session-start/worktree-context-declines.json`로 suppress합니다.
 

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -31,8 +31,9 @@ TigerKit 자체 성능 개선, baseline, heuristic proof, performance proof, fal
 - plugin slash invocation은 `/tk:gap`입니다.
 - `tiger-kit gap` CLI 표현은 이 plugin command의 사용자 관점 alias로 취급합니다.
 - `/tk:gap`은 하나의 실행으로 동작합니다.
-- 기본 `/tk:gap`은 `GAP_READY` 또는 `GAP_BLOCKED` 중 하나로 끝납니다.
-- `GAP_READY`는 정확히 하나의 `tigerkit-launch-workflow` block과 workflow hash를 포함합니다.
+- 기본 `/tk:gap`은 `GAP_READY`, `GAP_BLOCKED`, 또는 `GAP_AUTO_LAUNCHED` 중 하나로 끝납니다.
+- `GAP_READY`는 정확히 하나의 `tigerkit-launch-workflow` block과 workflow hash를 포함하고, 실행은 `/tk:launch`로 넘깁니다.
+- `GAP_AUTO_LAUNCHED`는 같은 `/tk:gap` 호출 안에서 sealed workflow 생성 뒤 정식 `/tk:launch` 루틴까지 이어서 수행한 경우에만 사용합니다. 이 경우 `GAP_READY`로 보고하지 않고 workflow와 launch receipt를 함께 기록합니다.
 - `GAP_BLOCKED`는 unresolved decision/conflict/missing source를 기록하고 `tigerkit-launch-workflow` block을 포함하지 않습니다.
 - `/tk:gap --review`는 v7 Contract-based Gap Review compatibility mode입니다.
 - `--maintainer-proof`는 maintainer/self-eval 전용입니다. 일반 사용자 품질 모드가 아니며 기본 gap 결과를 더 강하게 만드는 옵션처럼 설명하지 않습니다.
@@ -51,8 +52,9 @@ TigerKit 자체 성능 개선, baseline, heuristic proof, performance proof, fal
 6. task graph, task별 `assumed_preconditions`, success/failure condition, verification gate, abort policy, commit policy, review_policy를 작성합니다.
 7. verification gate 중 static/read-only로 확인 가능한 항목을 봉인 전 preflight로 1회 확인하고, 도구 가정 불일치나 unmet precondition을 launch-blocking item으로 승격합니다.
 8. 이전 `/tk:launch` abort trace가 있으면 구조화된 gap input으로 반영해 같은 `HUMAN_DECISION_REQUIRED`/`VERIFICATION_FAILED` 사실을 재발견하지 않습니다.
-9. launch 가능하면 `GAP_READY`와 sealed `tigerkit-launch-workflow`를 저장합니다.
-10. launch 금지 사유가 남으면 `GAP_BLOCKED`와 blocked report를 저장합니다.
+9. launch 가능하면 sealed `tigerkit-launch-workflow`를 저장하고, 실행을 분리하면 `GAP_READY`를 보고합니다.
+10. 같은 호출 안에서 정식 launch 루틴까지 수행하는 host 자동화가 명시적으로 활성화되어 있으면 `/tk:launch` contract를 그대로 적용하고 `GAP_AUTO_LAUNCHED`로 보고합니다.
+11. launch 금지 사유가 남으면 `GAP_BLOCKED`와 blocked report를 저장합니다.
 
 Workflow hash는 fenced block body raw UTF-8 bytes를 LF로 정규화하고 final LF를 하나 보장한 뒤 SHA-256으로 계산합니다. opening/closing fence line은 hash에서 제외하고 YAML key sort나 normalize를 하지 않습니다.
 
@@ -717,8 +719,9 @@ Implementation 개선 작업에서는 `redesign -> analysis -> review -> feedbac
 
 인터페이스 요약:
 
-- `GAP_READY` 또는 `GAP_BLOCKED`, branch scope, artifact path, 다음 행동을 출력합니다.
+- `GAP_READY`, `GAP_AUTO_LAUNCHED`, 또는 `GAP_BLOCKED`, branch scope, artifact path, 다음 행동을 출력합니다.
 - `GAP_READY`는 workflow path, workflow hash, task count, verification gate count, autopilot allowed, commit policy를 출력합니다.
+- `GAP_AUTO_LAUNCHED`는 workflow path/hash와 launch receipt path, launch result, verification summary를 함께 출력합니다.
 - `GAP_BLOCKED`는 blocked reason count, human decision count, missing source count, blocked report path를 출력합니다.
 - `GAP_READY` artifact는 정확히 하나의 `tigerkit-gap-status` block과 정확히 하나의 `tigerkit-launch-workflow` block을 포함합니다.
 - `GAP_BLOCKED` artifact는 `tigerkit-launch-workflow` block을 포함하지 않습니다.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -15,6 +15,7 @@
     ],
     "gap_terminal_statuses": [
       "GAP_READY",
+      "GAP_AUTO_LAUNCHED",
       "GAP_BLOCKED"
     ],
     "launch_abort_codes": [
@@ -83,7 +84,7 @@
       "id": 1,
       "name": "gap-ready-produces-sealed-workflow",
       "prompt": "Evaluate default /tk:gap when enough source exists to create a launch workflow. Do not write files.",
-      "expected_output": "Should end with GAP_READY, include a sealed tigerkit-launch-workflow block, include workflow path, workflow hash, task count, verification gate count, task assumed_preconditions, readonly_preflight status, autopilot allowed false, commit policy preflight_decision_required, review_policy mode, and next action /tk:launch. GAP_READY cannot be claimed without a launch workflow or without checking static/read-only preflight predicates. User-facing stdout labels should be Korean, e.g. 브랜치 범위, 워크플로, 검증 게이트, 자동 실행 허용, 커밋 정책, 다음 행동.",
+      "expected_output": "Should end with GAP_READY, include a sealed tigerkit-launch-workflow block, include workflow path, workflow hash, task count, verification gate count, task assumed_preconditions, readonly_preflight status, autopilot allowed false, commit policy preflight_decision_required, review_policy mode, and next action /tk:launch. GAP_READY cannot be claimed without a launch workflow or without checking static/read-only preflight predicates, and cannot be used when the same /tk:gap call continues into launch execution; that integrated path must report GAP_AUTO_LAUNCHED with workflow and launch receipt evidence. User-facing stdout labels should be Korean, e.g. 브랜치 범위, 워크플로, 검증 게이트, 자동 실행 허용, 커밋 정책, 다음 행동.",
       "files": [
         "commands/gap.md",
         ".tigerkit/docs/output-contract.md",


### PR DESCRIPTION
## 요약
- 이슈: #113 bug: 간단한 작업 검토 요청 시, gap 이후 봉인된 workflow를 스스로 launch 해버립니다.
- 수정: .claude-plugin/plugin.json, .tigerkit/docs/output-contract.md, .tigerkit/docs/usage.md 등 6개 파일
- 검증: 4개 로컬 검증 통과

## 검증 결과
- `claude plugin validate .claude-plugin/plugin.json`: PASS
- `claude plugin validate .`: PASS
- `python3 -m json.tool evals/evals.json`: PASS
- `git diff --check`: PASS

Closes #113