### PR TITLE
docs: clarify legacy TigerKit state boundary

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 남기는 경량 TigerKit Claude Code 플러그인입니다.",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -2,7 +2,9 @@
 
 이 문서는 현재 TigerKit 산출물 배치와 책임을 설명합니다. `.claude/tigerkit/`에 무엇을 두고 무엇을 두지 않는지는 `.tigerkit/docs/storage-boundary.md`를 기준으로 봅니다.
 
-## 현재 generated 구조
+현재 문서화된 repo-inside layout은 current/legacy generated state입니다. 계획된 external-state 방향은 project repository 밖의 `~/.tigerkit/` 아래에 TigerKit state를 두는 것이지만, 이 저장소에는 아직 해당 runtime write path 구현이 없습니다.
+
+## 현재/legacy generated 구조
 
 ```text
 .claude/
@@ -56,10 +58,10 @@ workspace-<basename-slug>--<sha256(absWorkspaceRoot).slice(0, 8)>
 
 ## Git ignore
 
-권장 `.gitignore`:
+현재/legacy repo-inside state에 대한 권장 `.gitignore`:
 
 ```gitignore
 .claude/tigerkit/
 ```
 
-`.claude/` 전체를 ignore하지 않습니다.
+`.claude/` 전체를 ignore하지 않습니다. 계획된 `~/.tigerkit/` external state는 project repository 밖에 있으므로 repo `.gitignore` 대상이 아닙니다.

--- a/.tigerkit/docs/storage-boundary.md
+++ b/.tigerkit/docs/storage-boundary.md
@@ -1,18 +1,22 @@
-# TigerKit `.claude/tigerkit` storage boundary
+# TigerKit storage boundary
 
-이 문서는 `.claude/tigerkit/`에 둘 수 있는 generated state와 두면 안 되는 durable surface를 구분한다.
+이 문서는 TigerKit generated state의 현재 repo-inside layout과 계획된 external-state 방향을 구분한다.
 
 ## Core rule
 
 ```text
-.claude/tigerkit/ = branch/workspace-local generated state only
+current/legacy repo-inside state = .claude/tigerkit/ branch/workspace-local generated state only
 ```
 
 `.claude/tigerkit/`는 durable repo guidance, shared team rule, user-global guidance, user skill source의 canonical home이 아니다.
 
-## Active generated contents
+## Planned direction (not active contract)
 
-현재 문서화된 active generated layout은 gap report와 branch pointer만 포함한다.
+RFC 방향으로는 TigerKit runtime state를 project repository 밖 `~/.tigerkit/` 아래로 외부화할 수 있다. 다만 현재 저장소에는 해당 runtime write path 구현이 없으므로, 이 문서는 그 external-state sublayout이나 scoping rule을 활성 contract로 정의하지 않는다.
+
+## Current/legacy generated contents
+
+현재 문서화된 repo-inside generated layout은 gap report와 branch pointer만 포함한다. 이 layout은 기존 호환을 위한 current/legacy 상태이며, 향후 external-state 방향은 project repository 밖의 `~/.tigerkit/` 아래에 TigerKit state를 두는 것이다.
 
 ```text
 .claude/tigerkit/branches/<scope-key>/gap/<GAP-ID>.md
@@ -73,13 +77,13 @@ Receipt가 proposal을 포함해도 아래를 뜻하지 않는다.
 
 ## Git policy
 
-`.claude/tigerkit/`는 generated state이므로 git ignore 대상이다.
+현재/legacy `.claude/tigerkit/` repo-inside state는 generated state이므로 git ignore 대상이다.
 
 ```gitignore
 .claude/tigerkit/
 ```
 
-`.claude/` 전체를 ignore 대상으로 확대하지 않는다.
+`.claude/` 전체를 ignore 대상으로 확대하지 않는다. 계획된 `~/.tigerkit/` external state는 project repository 밖에 있으므로 repo `.gitignore` 대상이 아니다.
 
 ## Review checklist
 
@@ -93,4 +97,4 @@ Receipt가 proposal을 포함해도 아래를 뜻하지 않는다.
 
 ## Bottom line
 
-`.claude/tigerkit/`는 branch/workspace-local generated state 영역이다. Durable guidance와 user skill source의 canonical storage로 확장하지 않는다.
+`.claude/tigerkit/`는 현재/legacy branch/workspace-local generated state 영역이다. Durable guidance와 user skill source의 canonical storage로 확장하지 않는다. 향후 external-state 방향은 repo 밖 `~/.tigerkit/`로 이동하는 것이지만, 이 저장소의 현재 runtime write path는 아직 그 구현을 제공하지 않는다.

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -38,4 +38,4 @@ TigerKit = gap + reflect
 
 ## Generated state
 
-`.claude/tigerkit/`은 generated branch/workspace-local memory입니다. durable repo knowledge가 아닙니다.
+현재 문서화된 repo-inside state는 `.claude/tigerkit/` 아래의 current/legacy branch/workspace-local memory입니다. durable repo knowledge가 아닙니다. 계획된 external-state 방향은 project repository 밖의 `~/.tigerkit/` 아래에 TigerKit state를 두는 것이지만, 이 저장소에는 아직 해당 runtime write path 구현이 없습니다.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ TigerKit은 아래를 active surface로 제공하지 않습니다.
 
 ## Generated State
 
-`.claude/tigerkit/`은 branch/workspace-local generated state이므로 git ignore 대상입니다. 현재 문서화된 active generated layout은 gap report와 branch pointer만 포함합니다. `.claude/` 전체를 ignore하지 않습니다.
+현재 문서화된 repo-inside generated state는 `.claude/tigerkit/` 아래의 branch/workspace-local gap report와 branch pointer뿐입니다. 이 layout은 current/legacy 상태이며 git ignore 대상입니다. 계획된 external-state 방향은 project repository 밖의 `~/.tigerkit/` 아래에 TigerKit state를 두는 것입니다. 이 저장소에는 아직 `~/.tigerkit/` runtime write path 구현이 없으므로 `.claude/` 전체를 ignore하지 않습니다.
 
 ## Contributors
 


### PR DESCRIPTION
## 요약
- 수정: `.claude/tigerkit` 기반 repo-inside generated state를 current/legacy layout으로 명시하고, 계획된 `~/.tigerkit` external-state 방향은 아직 active runtime contract가 아님을 문서 전반에서 분리했습니다.
- 이유: hidden repo path가 generated state와 durable docs 경계를 흐리게 만들어 branch-local처럼 오해되는 문제를 줄이기 위한 첫 문서화 슬라이스입니다.
- 검증: plugin/marketplace validation, JSON validation, version invariant check, `git diff --check`를 모두 통과했습니다.

## 변경 파일
- `.claude-plugin/plugin.json` (`14.1.2`)
- `README.md`
- `.tigerkit/docs/storage-boundary.md`
- `.tigerkit/docs/artifact-layout.md`
- `.tigerkit/docs/usage.md`

## 의도적으로 미룬 것
- `~/.tigerkit/` runtime write path 구현
- legacy state migration helper
- hidden tracked docs를 `docs/`로 이동하는 구조 변경

## 검증
- `python3 scripts/bump-plugin-version.py --part patch`
- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .`
- `git diff --check`
- `python3 -m json.tool evals/evals.json >/dev/null`
- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- `python3 scripts/check-plugin-version.py`
