### PR TITLE
feat: add TigerKit external state writer

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 남기는 경량 TigerKit Claude Code 플러그인입니다.",
-  "version": "14.1.3",
+  "version": "14.1.4",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -49,6 +49,7 @@ workspace-<basename-slug>--<sha256(absWorkspaceRoot).slice(0, 8)>
 | `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/<GAP-ID>.md` | `/tk:gap` one-shot report archive | generated working memory |
 | `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/current.md` | 최신 gap report copy | generated pointer |
 | `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/branch-state.json` | latest generated artifact pointer | generated index |
+| `scripts/tigerkit_state.py` | active generated state helper (`write-gap`, `record-session-start-decline`, path calculation) | shipped helper |
 | repo `CLAUDE.local.md` | reflect repo-local auto apply target | local guidance |
 | repo `CLAUDE.md` | reflect suggest-only target | shared repo guidance |
 

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -38,7 +38,19 @@ TigerKit = gap + reflect
 
 ## Generated state
 
-Active TigerKit generated state는 project repository 밖 `~/.tigerkit/` 아래의 file-only state입니다. `.claude/tigerkit/`는 legacy/migration context로만 남기고 새 runtime write path로 사용하지 않습니다.
+Active TigerKit generated state는 project repository 밖 `~/.tigerkit` 아래의 file-only state입니다. `.claude/tigerkit`는 legacy/migration context로만 남기고 새 runtime write path로 사용하지 않습니다.
+
+실제 write helper:
+
+```bash
+python3 scripts/tigerkit_state.py write-gap --repo-root "$PWD" --report-file /absolute/path/to/final-gap-report.md
+```
+
+SessionStart decline marker 기록 helper:
+
+```bash
+python3 scripts/tigerkit_state.py record-session-start-decline --signature <sig> --current-root <path> --source-root <path>
+```
 
 주요 active path:
 

--- a/commands/gap.md
+++ b/commands/gap.md
@@ -94,7 +94,24 @@ Findings에는 P0/P1/P2만 넣습니다. P3, duplicate, unverifiable, source con
 ```text
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/GAP-YYYYMMDD-HHmmss-RAND.md
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/current.md
+~/.tigerkit/repos/<repo-key>/branches/<scope-key>/branch-state.json
 ```
+
+실제 저장이 필요할 때는 최종 markdown report를 만든 뒤 아래 helper를 사용합니다.
+
+```bash
+python3 scripts/tigerkit_state.py write-gap --repo-root "$PWD" --report-file /absolute/path/to/final-gap-report.md
+```
+
+stdin으로 직접 넘길 수도 있습니다.
+
+```bash
+python3 scripts/tigerkit_state.py write-gap --repo-root "$PWD" <<'EOF'
+<final gap markdown>
+EOF
+```
+
+helper는 report archive, `current.md`, `branch-state.json`을 함께 갱신합니다.
 
 기존 `.claude/tigerkit/branches/<scope-key>/gap/` report는 migration context로 읽을 수 있지만 새 report write path로 사용하지 않습니다.
 

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -125,6 +125,7 @@
       "files": [
         "hooks/session-start",
         "commands/gap.md",
+        "scripts/tigerkit_state.py",
         ".tigerkit/docs/storage-boundary.md",
         ".tigerkit/docs/artifact-layout.md",
         ".tigerkit/docs/reflect-promotion-helpers.md",
@@ -134,6 +135,7 @@
       "expectations": [
         "active generated state under ~/.tigerkit outside project repository",
         "active SessionStart decline marker under ~/.tigerkit/local/session-start/worktree-context-declines.json",
+        "active helper script writes gap report/current/branch-state under ~/.tigerkit",
         ".claude/tigerkit legacy migration context only",
         "legacy decline marker read fallback allowed",
         "new writes go to external state",

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -204,6 +204,7 @@ Safety contract:
 - Never symlink .claude/ as a whole directory.
 - Never symlink node_modules by default.
 - If the user declines this proposal, record the candidate signature in the external decline marker and do not ask again for the same signature.
+- Record the decline with: `python3 scripts/tigerkit_state.py record-session-start-decline --signature "${signature}" --current-root "${current_root}" --source-root "${source_worktree}"`
 - Read legacy repo-local decline markers only as migration fallback; new decline writes go to the external marker.
 
 Command behavior:

--- a/scripts/tigerkit_state.py
+++ b/scripts/tigerkit_state.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def slugify(value: str) -> str:
+    value = value.strip().lower()
+    value = re.sub(r"[^a-z0-9._-]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-._")
+    return value or "workspace"
+
+
+def sha8(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+
+
+def state_root() -> Path:
+    custom = os.environ.get("TIGERKIT_STATE_ROOT")
+    if custom:
+        return Path(custom).expanduser()
+    return Path.home() / ".tigerkit"
+
+
+def abs_dir(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def git(*args: str, cwd: Path) -> str | None:
+    result = subprocess.run(["git", *args], cwd=str(cwd), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def resolve_repo_root(start: str | None) -> Path:
+    cwd = abs_dir(start or os.getcwd())
+    repo = git("rev-parse", "--show-toplevel", cwd=cwd)
+    return abs_dir(repo) if repo else cwd
+
+
+def repo_key(repo_root: Path) -> str:
+    return f"{slugify(repo_root.name)}--{sha8(str(repo_root))}"
+
+
+def scope_key(repo_root: Path) -> str:
+    branch = git("branch", "--show-current", cwd=repo_root)
+    if branch:
+        return slugify(branch)
+    return f"workspace-{slugify(repo_root.name)}--{sha8(str(repo_root))}"
+
+
+def atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile("w", encoding="utf-8", delete=False, dir=str(path.parent), prefix=".tmp-") as tmp:
+        tmp.write(text)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        temp_name = tmp.name
+    Path(temp_name).replace(path)
+
+
+def atomic_write_json(path: Path, payload: Any) -> None:
+    atomic_write(path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+
+
+def load_json(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return default
+
+
+def next_gap_id() -> str:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    rand = hashlib.sha256(f"{stamp}-{os.getpid()}-{os.urandom(8).hex()}".encode()).hexdigest()[:4].upper()
+    return f"GAP-{stamp}-{rand}"
+
+
+def cmd_gap_paths(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(args.repo_root)
+    repo_key_value = repo_key(repo_root)
+    scope_key_value = scope_key(repo_root)
+    root = state_root()
+    gap_dir = root / "repos" / repo_key_value / "branches" / scope_key_value / "gap"
+    payload = {
+        "stateRoot": str(root),
+        "repoRoot": str(repo_root),
+        "repoKey": repo_key_value,
+        "scopeKey": scope_key_value,
+        "gapDir": str(gap_dir),
+        "currentPath": str(gap_dir / "current.md"),
+        "branchStatePath": str(root / "repos" / repo_key_value / "branches" / scope_key_value / "branch-state.json"),
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+def cmd_write_gap(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(args.repo_root)
+    repo_key_value = repo_key(repo_root)
+    scope_key_value = scope_key(repo_root)
+    root = state_root()
+    content = Path(args.report_file).read_text(encoding="utf-8") if args.report_file else sys.stdin.read()
+    if not content.strip():
+        raise SystemExit("write-gap requires non-empty report content")
+    gap_id = args.gap_id or next_gap_id()
+    gap_dir = root / "repos" / repo_key_value / "branches" / scope_key_value / "gap"
+    report_path = gap_dir / f"{gap_id}.md"
+    current_path = gap_dir / "current.md"
+    branch_state_path = root / "repos" / repo_key_value / "branches" / scope_key_value / "branch-state.json"
+    atomic_write(report_path, content)
+    atomic_write(current_path, content)
+    branch_state = load_json(branch_state_path, {})
+    branch_state.update({
+        "repoKey": repo_key_value,
+        "scopeKey": scope_key_value,
+        "lastGapRunId": gap_id,
+        "lastGapRunPath": str(report_path),
+        "updatedAt": now_iso(),
+    })
+    atomic_write_json(branch_state_path, branch_state)
+    print(json.dumps({
+        "stateRoot": str(root),
+        "repoRoot": str(repo_root),
+        "repoKey": repo_key_value,
+        "scopeKey": scope_key_value,
+        "gapId": gap_id,
+        "reportPath": str(report_path),
+        "currentPath": str(current_path),
+        "branchStatePath": str(branch_state_path),
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+def cmd_record_decline(args: argparse.Namespace) -> int:
+    root = state_root()
+    marker = root / "local" / "session-start" / "worktree-context-declines.json"
+    data = load_json(marker, {"declines": []})
+    declines = data.get("declines") if isinstance(data, dict) else None
+    if not isinstance(declines, list):
+        declines = []
+        data = {"declines": declines}
+    existed = any(isinstance(item, dict) and item.get("signature") == args.signature for item in declines)
+    if not existed:
+        declines.append({
+            "signature": args.signature,
+            "currentRoot": args.current_root,
+            "sourceRoot": args.source_root,
+            "createdAt": now_iso(),
+        })
+        atomic_write_json(marker, data)
+    print(json.dumps({
+        "stateRoot": str(root),
+        "markerPath": str(marker),
+        "signature": args.signature,
+        "alreadyPresent": existed,
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="TigerKit generated state helpers")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_paths = sub.add_parser("gap-paths", help="Print active gap state paths")
+    p_paths.add_argument("--repo-root", help="Repo root or working directory", default=None)
+    p_paths.set_defaults(func=cmd_gap_paths)
+
+    p_write = sub.add_parser("write-gap", help="Write a gap report into ~/.tigerkit")
+    p_write.add_argument("--repo-root", help="Repo root or working directory", default=None)
+    p_write.add_argument("--gap-id", help="Explicit GAP id", default=None)
+    p_write.add_argument("--report-file", help="Read report content from file instead of stdin", default=None)
+    p_write.set_defaults(func=cmd_write_gap)
+
+    p_decline = sub.add_parser("record-session-start-decline", help="Persist a declined session-start signature")
+    p_decline.add_argument("--signature", required=True)
+    p_decline.add_argument("--current-root", default="")
+    p_decline.add_argument("--source-root", default="")
+    p_decline.set_defaults(func=cmd_record_decline)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 요약
- 수정: TigerKit external generated state를 문서/계약 수준이 아니라 실제 helper script로 쓰도록 구현했습니다.
- 구현: `scripts/tigerkit_state.py`를 추가해 `~/.tigerkit` 아래에 gap report archive, `current.md`, `branch-state.json`, SessionStart decline marker를 실제로 기록할 수 있게 했습니다.
- 정합성: `commands/gap.md`, `hooks/session-start`, `.tigerkit/docs/artifact-layout.md`, `.tigerkit/docs/usage.md`, `evals/evals.json`를 새 helper surface에 맞게 동기화했습니다.
- 검증: plugin/marketplace validation, JSON validation, version invariant check, `git diff --check`, 그리고 실제 `~/.tigerkit` smoke write를 확인했습니다.

## 실제 write 증거
- helper command:
  - `python3 scripts/tigerkit_state.py write-gap --repo-root "$PWD" --gap-id GAP-SMOKE-WRITE --report-file /tmp/tigerkit-gap-smoke.md`
- 생성 확인:
  - `~/.tigerkit/repos/tiger-kit--db4f0901/branches/feat-externalize-tigerkit-writer/gap/GAP-SMOKE-WRITE.md`
  - `~/.tigerkit/repos/tiger-kit--db4f0901/branches/feat-externalize-tigerkit-writer/gap/current.md`
  - `~/.tigerkit/repos/tiger-kit--db4f0901/branches/feat-externalize-tigerkit-writer/branch-state.json`

## 변경 파일
- `.claude-plugin/plugin.json` (`14.1.4`)
- `scripts/tigerkit_state.py`
- `hooks/session-start`
- `commands/gap.md`
- `.tigerkit/docs/artifact-layout.md`
- `.tigerkit/docs/usage.md`
- `evals/evals.json`

## 검증
- `python3 scripts/bump-plugin-version.py --part patch`
- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .`
- `git diff --check`
- `python3 -m json.tool evals/evals.json >/dev/null`
- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- `python3 scripts/check-plugin-version.py`
