### PR TITLE
feat: add loop-spec recommendation command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "MTGVim"
   },
   "metadata": {
-    "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 preview-first로 남기는 hook-free TigerKit Claude Code 플러그인입니다."
+    "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 남기며, 명시적 task는 loop-spec으로 추천 계약을 생성하는 hook-free TigerKit Claude Code 플러그인입니다."
   },
   "plugins": [
     {
       "name": "tk",
       "source": "./",
-      "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 preview-first로 남기는 hook-free TigerKit Claude Code 플러그인입니다."
+      "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 남기며, 명시적 task는 loop-spec으로 추천 계약을 생성하는 hook-free TigerKit Claude Code 플러그인입니다."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "tk",
-  "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 preview-first로 남기는 hook-free TigerKit Claude Code 플러그인입니다.",
-  "version": "15.0.0",
+  "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 남기며, 명시적 task는 loop-spec으로 추천 계약을 생성하는 hook-free TigerKit Claude Code 플러그인입니다.",
+  "version": "16.0.0",
   "author": {
     "name": "MTGVim"
   },
   "commands": [
     "./commands/gap.md",
-    "./commands/reflect.md"
+    "./commands/reflect.md",
+    "./commands/loop-spec.md"
   ]
 }

--- a/.tigerkit/docs/artifact-layout.md
+++ b/.tigerkit/docs/artifact-layout.md
@@ -15,6 +15,9 @@
           gap/
             GAP-YYYYMMDD-HHmmss-RAND.md
             current.md
+          loop-specs/
+            <spec-id>/
+              spec.yaml
           branch-state.json
 ```
 
@@ -45,6 +48,7 @@ workspace-<basename-slug>--<sha256(absWorkspaceRoot).slice(0, 8)>
 | `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/<GAP-ID>.md` | `/tk:gap` one-shot report archive | generated working memory |
 | `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/current.md` | 최신 gap report copy | generated pointer |
 | `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/branch-state.json` | latest generated artifact pointer | generated index |
+| `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/loop-specs/<spec-id>/spec.yaml` | `/tk:loop-spec` recommendation contract | worktree-scoped generated spec |
 | `scripts/tigerkit_state.py` | active generated state helper (`write-gap`, path calculation) | shipped helper |
 | repo `CLAUDE.local.md` | reflect eligible repo-local apply target | local guidance |
 | repo `CLAUDE.md` | reflect suggest-only target | shared repo guidance |

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -9,7 +9,7 @@
 - Evidence, Interpretation, Decision, Suggestion을 구분합니다.
 - 검증하지 않은 success를 선언하지 않습니다.
 - command가 파일을 쓰면 changed path를 출력합니다.
-- Core `tk` plugin은 hook-free이며 active command surface는 `/tk:gap`, `/tk:reflect`뿐입니다.
+- Core `tk` plugin은 hook-free이며 active command surface는 `/tk:gap`, `/tk:reflect`, `/tk:loop-spec`입니다.
 
 ## `/tk:gap` Output Contract
 
@@ -241,6 +241,46 @@ Changed paths:
 Applied candidates: NONE
 Required action: inspect target manually before rerun
 ```
+
+
+## `/tk:loop-spec` Output Contract
+
+`/tk:loop-spec`은 명시적 task를 실행 없는 LoopSpec recommendation으로 컴파일하거나 기존 spec의 schema/context freshness를 검증합니다.
+
+```text
+Loop strategy: <motif or not-recommended>
+Applicability: recommended | conditional | not-recommended
+Readiness: complete | incomplete | manual
+Fit score: <0..100>/100
+Confidence: high | medium | low
+Worktree: <branch or workspace>
+
+Why
+  - <reason and provenance>
+
+Blockers
+  - <blocker or NONE>
+
+Guards
+  - <guard>
+
+Saved
+  <~/.tigerkit/.../loop-specs/<spec-id>/spec.yaml or NONE>
+
+Write receipt
+  changed: <path or NONE>
+  source tree changed: no
+```
+
+Validation output:
+
+```text
+LoopSpec: <id or path>
+Schema: valid | invalid
+Context: current | stale | unknown
+```
+
+`not-recommended`와 stale context는 정상 domain result입니다. Raw diff content와 secret content는 spec 또는 scanner artifact에 저장하지 않습니다.
 
 ## Deprecated output surfaces
 

--- a/.tigerkit/docs/storage-boundary.md
+++ b/.tigerkit/docs/storage-boundary.md
@@ -19,6 +19,7 @@ Core `tk` plugin은 hook-free다. Active generated state는 project repository �
 ```text
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/<GAP-ID>.md
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/current.md
+~/.tigerkit/repos/<repo-key>/branches/<scope-key>/loop-specs/<spec-id>/spec.yaml
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/branch-state.json
 ```
 
@@ -26,6 +27,7 @@ Core `tk` plugin은 hook-free다. Active generated state는 project repository �
 
 - `/tk:gap` one-shot report archive
 - latest gap report pointer
+- `/tk:loop-spec` worktree-scoped recommendation spec
 - branch/workspace-local generated index
 
 `repo-key`는 repo root를 기준으로 만든 stable key다. 권장 형식:

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -9,13 +9,14 @@
 ## 핵심 모델
 
 ```text
-TigerKit = gap + reflect
+TigerKit = gap + reflect + loop-spec
 ```
 
 - `gap`: SoT와 Current Implementation의 차이를 한 번 분석합니다. evidence-first로 읽고, source conflict나 근거 부족은 `ambiguous`로 남깁니다.
 - `reflect`: 세션 result와 feedback에서 재사용 가능한 learning을 preview-first promotion result로 분류합니다.
+- `loop-spec`: 명시적 task를 read-only worktree scan 기반의 실행 없는 LoopSpec recommendation으로 컴파일하거나 검증합니다.
 
-Core `tk` plugin은 hook-free입니다. Active command surface는 `/tk:gap`, `/tk:reflect`뿐입니다.
+Core `tk` plugin은 hook-free입니다. Active command surface는 `/tk:gap`, `/tk:reflect`, `/tk:loop-spec`입니다.
 
 ## Core guidance
 
@@ -31,6 +32,7 @@ Core `tk` plugin은 hook-free입니다. Active command surface는 `/tk:gap`, `/t
 |---|---|---|
 | `/tk:gap` | SoT와 Current를 비교해 missing, mismatch, overbuilt, ambiguous를 보고합니다. | optional external generated report |
 | `/tk:reflect` | session result와 feedback에서 개선 후보를 canonical target으로 분류합니다. | promotion candidates |
+| `/tk:loop-spec` | 명시적 task와 현재 worktree capability를 읽기 전용으로 분석해 LoopSpec recommendation을 생성하거나 검증합니다. | worktree-scoped generated spec |
 
 ## 사용 예시
 
@@ -38,6 +40,8 @@ Core `tk` plugin은 hook-free입니다. Active command surface는 `/tk:gap`, `/t
 /tk:gap "PRD와 현재 구현 차이 봐줘" --target src/auth
 /tk:reflect --target repo --apply=false
 /tk:reflect --target repo-local --apply=true
+/tk:loop-spec "결제 모달 scroll 복구 버그 수정"
+/tk:loop-spec validate <spec-id-or-path>
 ```
 
 ## Reflect target model
@@ -91,6 +95,7 @@ python3 scripts/tigerkit_state.py write-gap --repo-root "$PWD" --report-file /ab
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/<GAP-ID>.md
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/gap/current.md
 ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/branch-state.json
+~/.tigerkit/repos/<repo-key>/branches/<scope-key>/loop-specs/<spec-id>/spec.yaml
 ```
 
 ## Legacy state

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 </p>
 
 TigerKit(`tk`, plugin namespace `/tk:*`)은 Claude Code용 경량 plugin입니다.
-SoT(Source of Truth)가 있으면 `/tk:gap`으로 현재 구현과의 차이를 먼저 확인하고, 의미 있는 작업이 끝나면 `/tk:reflect`로 재사용 가능한 learning을 preview-first로 정리합니다. `gap`은 evidence-first로 읽고, source conflict나 근거 부족은 `ambiguous`로 남깁니다.
+SoT(Source of Truth)가 있으면 `/tk:gap`으로 현재 구현과의 차이를 먼저 확인하고, 의미 있는 작업이 끝나면 `/tk:reflect`로 재사용 가능한 learning을 preview-first로 정리합니다. 명시적 task는 `/tk:loop-spec`으로 실행 없는 loop recommendation 계약을 생성할 수 있습니다. `gap`은 evidence-first로 읽고, source conflict나 근거 부족은 `ambiguous`로 남깁니다.
 
 ```text
 Check the gap first. Keep the learning.
 ```
 
-공개 실행 표면은 `/tk:gap`, `/tk:reflect` 두 명령입니다. Core `tk` plugin은 hook-free이며 workflow runner, subagent orchestrator, setup wizard를 제공하지 않습니다. `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다.
+공개 실행 표면은 `/tk:gap`, `/tk:reflect`, `/tk:loop-spec` 세 명령입니다. Core `tk` plugin은 hook-free이며 workflow runner, subagent orchestrator, setup wizard, autopilot을 제공하지 않습니다. `commands/*.md`와 `.claude-plugin/plugin.json`이 `/tk:*` contract를 소유합니다.
 
 ## Installation
 
@@ -39,7 +39,7 @@ claude plugin details tk
 claude plugin install tk@tiger-kit --scope project
 ```
 
-설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:reflect` 명령을 사용합니다.
+설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:reflect`, `/tk:loop-spec` 명령을 사용합니다.
 
 ## Core guidance
 
@@ -55,6 +55,7 @@ claude plugin install tk@tiger-kit --scope project
 | --- | --- | --- |
 | `/tk:gap` | SoT와 Current Implementation의 차이를 한 번 확인하고 missing, mismatch, overbuilt, ambiguous를 정리합니다. evidence-first로 읽고 source conflict는 `ambiguous`로 남깁니다. | optional external generated report |
 | `/tk:reflect` | 세션 결과와 사용자 피드백에서 재사용 가능한 learning을 canonical target(`repo-local`, `repo-shared`, `user-global`, `skill`, `hook`, `command`, `agent`, `discard`)으로 분류합니다. 기본값은 preview-only입니다. | promotion candidates |
+| `/tk:loop-spec` | 명시적 task와 현재 worktree capability를 읽기 전용으로 분석해 loop recommendation `LoopSpec`을 생성하거나 검증합니다. 실행기/approval/autopilot은 포함하지 않습니다. | worktree-scoped generated spec |
 
 ## 사용 예시
 
@@ -62,6 +63,8 @@ claude plugin install tk@tiger-kit --scope project
 /tk:gap "PRD와 현재 구현 차이 봐줘" --target src/auth
 /tk:reflect --target repo --apply=false
 /tk:reflect --target repo-local --apply=true
+/tk:loop-spec "결제 모달 scroll 복구 버그 수정"
+/tk:loop-spec validate <spec-id-or-path>
 ```
 
 ## Reflect write boundary
@@ -87,6 +90,7 @@ TigerKit은 아래를 active surface로 제공하지 않습니다.
 - `setup`
 - launch / review / next / handoff workflow
 - mandatory runner or autopilot
+- `/tk:loop-spec` 기반 자동 실행 또는 approval lifecycle
 - Patron / subagent delegation
 - active `SessionStart` hook
 - hook settings, command source, agent source 자동 생성
@@ -101,7 +105,7 @@ TigerKit은 아래를 active surface로 제공하지 않습니다.
 
 ## Generated State
 
-Active generated state는 project repository 밖 `~/.tigerkit/` 아래의 file-only state입니다. `/tk:gap` report와 branch pointer는 `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/...` 아래에 둡니다. Core `tk` plugin은 active `SessionStart` hook을 제공하지 않으며, 기존 SessionStart decline marker는 legacy/inactive state로만 보존되고 core command/runtime이 읽거나 쓰지 않습니다. `.claude/tigerkit/`는 legacy/migration context로만 남기며 `.claude/` 전체를 ignore하지 않습니다.
+Active generated state는 project repository 밖 `~/.tigerkit/` 아래의 file-only state입니다. `/tk:gap` report, branch pointer, `/tk:loop-spec` spec은 `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/...` 아래에 둡니다. Core `tk` plugin은 active `SessionStart` hook을 제공하지 않으며, 기존 SessionStart decline marker는 legacy/inactive state로만 보존되고 core command/runtime이 읽거나 쓰지 않습니다. `.claude/tigerkit/`는 legacy/migration context로만 남기며 `.claude/` 전체를 ignore하지 않습니다.
 
 ## Contributors
 

--- a/commands/loop-spec.md
+++ b/commands/loop-spec.md
@@ -1,0 +1,99 @@
+---
+description: 명시적 task를 worktree-scoped LoopSpec recommendation으로 컴파일합니다.
+argument-hint: '"<task>" [--explain] [--type bugfix|refactor|flaky-test] [--motif <motif>] [--name <name>] [--no-write] | validate <spec-id-or-path>'
+---
+
+이 문서는 TigerKit `/tk:loop-spec` command contract를 정의합니다.
+
+사용자에게는 한글로 답합니다. 코드, path, URL, identifier, command, YAML/JSON field name은 원문 그대로 둘 수 있습니다.
+
+목표: `/tk:loop-spec`은 사용자가 명시적으로 입력한 개발 task와 현재 worktree의 read-only capability를 분석해, 실행하지 않는 loop recommendation인 `LoopSpec`을 생성하거나 기존 spec을 검증합니다.
+
+```text
+loop-spec = explicit task + read-only worktree scan -> recommendation + LoopSpec
+```
+
+## Core boundary
+
+- `/tk:loop-spec`은 `/tk:gap`의 확장이 아닙니다.
+- `/tk:gap`은 `/tk:loop-spec`을 자동 호출하거나 자동 제안하지 않습니다.
+- 이 command는 source tree, `.claude/tigerkit/`, Git branch/index/stash/commit을 변경하지 않습니다.
+- package-manager script, build, test, lint, typecheck, network request를 실행하지 않습니다.
+- 실행기, runner, approval, autopilot, orchestration은 이 command의 범위가 아닙니다.
+
+## MVP surface
+
+```bash
+/tk:loop-spec "<task>"
+/tk:loop-spec validate <spec-id-or-path>
+```
+
+Generate options:
+
+```bash
+/tk:loop-spec "<task>" --explain
+/tk:loop-spec "<task>" --type bugfix
+/tk:loop-spec "<task>" --type refactor
+/tk:loop-spec "<task>" --type flaky-test
+/tk:loop-spec "<task>" --motif reproduce-diagnose-patch-verify
+/tk:loop-spec "<task>" --name fix-payment-modal-scroll
+/tk:loop-spec "<task>" --no-write
+```
+
+MVP 범위 밖: `list`, `show`, `export`, `--from`, `--issue`, public JSON output, standalone CLI alias, `--probe`, LLM-assisted task analysis.
+
+## Execution instruction
+
+When this command is invoked, run the helper from the repository root:
+
+```bash
+python3 scripts/tigerkit_state.py loop-spec $ARGUMENTS
+```
+
+If the helper is unavailable, report the blocker instead of inventing a LoopSpec.
+
+## Output contract
+
+기본 출력은 아래 정보를 포함해야 합니다.
+
+```text
+Loop strategy: <motif or not-recommended>
+Applicability: recommended | conditional | not-recommended
+Readiness: complete | incomplete | manual
+Fit score: <0..100>/100
+Confidence: high | medium | low
+Worktree: <branch or workspace>
+
+Why
+  - <reason and provenance>
+
+Blockers
+  - <blocker or NONE>
+
+Guards
+  - <guard>
+
+Saved
+  <~/.tigerkit/.../loop-specs/<spec-id>/spec.yaml or NONE>
+
+Write receipt
+  changed: <path or NONE>
+  source tree changed: no
+```
+
+## Storage
+
+기본 artifact는 project repository 밖 active generated state에 저장합니다.
+
+```text
+~/.tigerkit/repos/<repo-key>/branches/<scope-key>/loop-specs/<spec-id>/spec.yaml
+```
+
+`--no-write`는 artifact를 쓰지 않고 recommendation만 출력합니다.
+
+## Safety invariants
+
+- Raw diff content와 secret content는 spec 또는 scanner artifact에 저장하지 않습니다.
+- Fingerprint에는 normalized metadata와 safe content hash만 기록합니다.
+- runnable, approval, agent/run lifecycle field는 schema에 포함하지 않습니다.
+- Command-level `execution` probe metadata는 discovery와 실제 command success를 구분하기 위해서만 사용합니다.

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -16,7 +16,7 @@ reflect = session result + feedback -> classify learning -> preview promotion re
 ## Core boundary
 
 - Core `tk` plugin은 hook-free입니다.
-- Core active command surface는 `/tk:gap`, `/tk:reflect`뿐입니다.
+- Core active command surface는 `/tk:gap`, `/tk:reflect`, `/tk:loop-spec`입니다.
 - `/tk:reflect`는 Claude Code auto memory를 쓰거나, mirror하거나, backup하지 않습니다.
 - `/tk:reflect`는 source code, hook settings, command source, agent source, skill source, plugin manifest를 수정하지 않습니다.
 - 기존 `SessionStart` decline marker와 `PROFILE.md`는 legacy/inactive state로만 취급하고 자동 삭제하거나 자동 이관하지 않습니다.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,10 +1,11 @@
 {
-  "skill_name": "tiger-kit-gap-reflect-core",
+  "skill_name": "tiger-kit-gap-reflect-loop-spec-core",
   "command_surface": {
-    "surface_model": "TigerKit exposes Claude Code plugin commands only; commands/*.md and .claude-plugin/plugin.json own /tk:* contracts. Core tk plugin is hook-free.",
+    "surface_model": "TigerKit exposes Claude Code plugin commands only; commands/*.md and .claude-plugin/plugin.json own /tk:* contracts. Core tk plugin is hook-free and exposes /tk:gap, /tk:reflect, and /tk:loop-spec.",
     "core_commands": [
       "/tk:gap",
-      "/tk:reflect"
+      "/tk:reflect",
+      "/tk:loop-spec"
     ],
     "deprecated_or_removed_commands": [
       "/tk:grill",
@@ -22,16 +23,17 @@
   "evals": [
     {
       "id": 0,
-      "name": "plugin-version-and-command-manifest-gap-reflect-hook-free",
+      "name": "plugin-version-and-command-manifest-gap-reflect-loop-spec-hook-free",
       "prompt": "Evaluate TigerKit active command surface and plugin packaging. Do not write files.",
-      "expected_output": "Should list /tk:gap and /tk:reflect as the only active commands. Should state core tk plugin is hook-free and has no active SessionStart hook packaging or helper runtime. Should state /tk:grill, /tk:afk, /tk:setup, and the launch-era commands are not active manifest entries.",
+      "expected_output": "Should list /tk:gap, /tk:reflect, and /tk:loop-spec as the active commands. Should state core tk plugin is hook-free and has no active SessionStart hook packaging or helper runtime. Should state /tk:grill, /tk:afk, /tk:setup, and the launch-era commands are not active manifest entries. Should state /tk:loop-spec is a read-only recommender/compiler, not a runner/autopilot.",
       "files": [
         ".claude-plugin/plugin.json",
         ".claude-plugin/marketplace.json",
         "hooks/hooks.json",
         "scripts/tigerkit_state.py",
         "README.md",
-        ".tigerkit/docs/usage.md"
+        ".tigerkit/docs/usage.md",
+        "commands/loop-spec.md"
       ],
       "expectations": [
         "Lists /tk:gap",
@@ -43,7 +45,9 @@
         "States core tk plugin is hook-free",
         "Does not package an active SessionStart hook",
         "Does not ship active hooks/session-start runtime",
-        "Does not ship active hooks/run-hook.cmd helper"
+        "Does not ship active hooks/run-hook.cmd helper",
+        "Lists /tk:loop-spec",
+        "States /tk:loop-spec is not a runner or autopilot"
       ]
     },
     {
@@ -557,6 +561,31 @@
         "helper docs do not imply install or generation",
         "user skill source not generated under TigerKit generated state",
         "Claude Code auto memory is not written mirrored or backed up"
+      ]
+    },
+    {
+      "id": 25,
+      "name": "loop-spec-read-only-recommendation-contract",
+      "prompt": "Evaluate /tk:loop-spec behavior. Do not write files.",
+      "expected_output": "Should treat /tk:loop-spec as an explicit-trigger read-only recommender/compiler that generates or validates LoopSpec artifacts under ~/.tigerkit/repos/<repo-key>/branches/<scope-key>/loop-specs/<spec-id>/spec.yaml. It must not run package scripts, tests, builds, network, runner/autopilot, approval lifecycle, or mutate source tree/.claude/tigerkit. It should separate command discovery from execution status and avoid storing raw diff or secret content.",
+      "files": [
+        "commands/loop-spec.md",
+        "scripts/tigerkit_state.py",
+        "README.md",
+        ".tigerkit/docs/output-contract.md",
+        ".tigerkit/docs/storage-boundary.md"
+      ],
+      "expectations": [
+        "Explicit /tk:loop-spec trigger only",
+        "Generates LoopSpec under ~/.tigerkit loop-specs path",
+        "Validate reports schema and context freshness",
+        "Does not mutate source tree",
+        "Does not write .claude/tigerkit",
+        "Does not run package scripts",
+        "No runner autopilot approval lifecycle",
+        "Separates command discovery and execution metadata",
+        "Does not store raw diff content",
+        "Does not store secret content"
       ]
     }
   ]

--- a/scripts/tigerkit_state.py
+++ b/scripts/tigerkit_state.py
@@ -147,6 +147,478 @@ def cmd_write_gap(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---- loop-spec helpers -------------------------------------------------
+LOOP_MOTIFS = {
+    "bugfix": "reproduce-diagnose-patch-verify",
+    "refactor": "inventory-batch-transform-verify",
+    "flaky-test": "repeat-trace-classify-patch-stress",
+}
+VALID_LOOP_TYPES = {"bugfix", "refactor", "flaky-test", "unknown"}
+VALID_MOTIFS = set(LOOP_MOTIFS.values())
+SECRET_NAME_RE = re.compile(r"(^|[._/-])(env|secret|secrets|credential|credentials|token|tokens|key|keys|passwd|password)([._/-]|$)", re.I)
+MAX_HASH_BYTES = 256_000
+SECRET_VALUE_RE = re.compile(r"(?i)\b(api[_-]?key|token|secret|password|passwd)\s*[:=]\s*([^\s]+)")
+
+
+def git_bytes(*args: str, cwd: Path) -> bytes | None:
+    result = subprocess.run(["git", *args], cwd=str(cwd), stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def git_lines_z(*args: str, cwd: Path) -> list[str]:
+    data = git_bytes(*args, cwd=cwd)
+    if data is None:
+        return []
+    return [item.decode("utf-8", "replace") for item in data.split(b"\0") if item]
+
+
+def next_loop_spec_id(name: str | None = None) -> str:
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    rand = hashlib.sha256(f"loop-{stamp}-{os.getpid()}-{os.urandom(8).hex()}".encode()).hexdigest()[:4].upper()
+    prefix = slugify(name) if name else "loop-spec"
+    return f"{prefix}-{stamp}-{rand}"
+
+
+def loop_spec_dir(repo_root: Path, spec_id: str | None = None) -> Path:
+    base = state_root() / "repos" / repo_key(repo_root) / "branches" / scope_key(repo_root) / "loop-specs"
+    return base / spec_id if spec_id else base
+
+
+def ensure_state_root_outside_repo(repo_root: Path) -> None:
+    root = state_root().expanduser().resolve()
+    try:
+        root.relative_to(repo_root.resolve())
+    except ValueError:
+        return
+    raise SystemExit("loop-spec state root must be outside the project repository")
+
+
+def sanitize_task_text(task: str) -> str:
+    return SECRET_VALUE_RE.sub(lambda m: f"{m.group(1)}=<redacted>", task)
+
+
+def is_secretish(path: str) -> bool:
+    lowered = path.lower()
+    return bool(SECRET_NAME_RE.search(lowered)) or lowered.endswith((".pem", ".p12", ".pfx", ".key"))
+
+
+def sha256_bytes(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def safe_file_hash(path: Path) -> tuple[str | None, str | None]:
+    try:
+        if not path.is_file() or path.is_symlink():
+            return None, "unsupported-file-type"
+        if is_secretish(str(path)):
+            return None, "secret-path"
+        size = path.stat().st_size
+        if size > MAX_HASH_BYTES:
+            return None, "size-limit"
+        return sha256_bytes(path.read_bytes()), None
+    except Exception:
+        return None, "read-error"
+
+
+def collect_changed_paths(repo_root: Path) -> tuple[list[dict[str, Any]], bool]:
+    partial = False
+    records: dict[str, dict[str, Any]] = {}
+    for item in git_lines_z("diff", "--no-ext-diff", "--name-status", "-z", "HEAD", cwd=repo_root):
+        # NUL name-status output alternates status/path for simple changes. Rename records may be imperfect;
+        # this scanner records metadata only and never raw diff content.
+        if item and not re.match(r"^[A-Z][0-9]*$", item):
+            records[item] = {"path": item, "status": "changed"}
+    numstat_data = git_bytes("diff", "--no-ext-diff", "--numstat", "-z", "HEAD", cwd=repo_root)
+    if numstat_data:
+        for raw in numstat_data.split(b"\0"):
+            if not raw:
+                continue
+            parts = raw.decode("utf-8", "replace").split("\t")
+            if len(parts) >= 3:
+                added, deleted, path = parts[0], parts[1], parts[2]
+                rec = records.setdefault(path, {"path": path, "status": "changed"})
+                rec["added"] = added
+                rec["deleted"] = deleted
+    for path in git_lines_z("ls-files", "--others", "--exclude-standard", "-z", cwd=repo_root):
+        records.setdefault(path, {"path": path, "status": "untracked"})
+    for rel, rec in list(records.items()):
+        digest, reason = safe_file_hash(repo_root / rel)
+        if digest:
+            rec["contentHash"] = digest
+        elif reason:
+            rec["hashExcludedReason"] = reason
+            partial = True
+    return [records[k] for k in sorted(records)], partial
+
+
+def scan_capabilities(repo_root: Path, task: str = "") -> dict[str, Any]:
+    package_json = repo_root / "package.json"
+    scripts: dict[str, str] = {}
+    deps: dict[str, str] = {}
+    package_manager = "yarn" if package_json.exists() else "unknown"
+    if (repo_root / "yarn.lock").exists():
+        package_manager = "yarn"
+    elif (repo_root / "pnpm-lock.yaml").exists():
+        package_manager = "pnpm"
+    elif (repo_root / "package-lock.json").exists():
+        package_manager = "npm"
+    if package_json.exists():
+        try:
+            pkg = json.loads(package_json.read_text(encoding="utf-8"))
+            scripts = {k: str(v) for k, v in (pkg.get("scripts") or {}).items()}
+            for field in ("dependencies", "devDependencies", "peerDependencies"):
+                deps.update({k: str(v) for k, v in (pkg.get(field) or {}).items()})
+            pm = pkg.get("packageManager")
+            if isinstance(pm, str):
+                package_manager = pm.split("@")[0]
+        except Exception:
+            pass
+    def has_dep(name: str) -> bool:
+        return name in deps or any(name in s for s in scripts.values())
+    commands: dict[str, Any] = {}
+    def add_cmd(key: str, script_name: str | None, run: str | None):
+        commands[key] = {
+            "run": run,
+            "discovery": {"status": "verified" if run else "unresolved", "source": f"package.json#scripts.{script_name}" if run and script_name else "repository-scan"},
+            "execution": {"status": "unprobed" if run else "not-applicable", "reason": "default-mode-is-read-only" if run else "command-not-resolved"},
+        }
+    type_script = next((s for s in ("type-check", "typecheck", "tsc") if s in scripts), None)
+    test_script = next((s for s in ("test", "vitest", "jest") if s in scripts), None)
+    lint_script = next((s for s in ("lint", "eslint") if s in scripts), None)
+    build_script = "build" if "build" in scripts else None
+    runner = package_manager if package_manager in {"yarn", "pnpm", "npm"} else "yarn"
+    add_cmd("typecheck", type_script, f"{runner} {type_script}" if type_script else None)
+    add_cmd("unit", test_script, f"{runner} {test_script}" if test_script else None)
+    add_cmd("lint", lint_script, f"{runner} {lint_script}" if lint_script else None)
+    add_cmd("build", build_script, f"{runner} {build_script}" if build_script else None)
+    e2e_script = next((s for s in scripts if any(w in s.lower() for w in ("e2e", "playwright", "cypress"))), None)
+    add_cmd("targetedE2E", e2e_script, f"{runner} {e2e_script}" if e2e_script else None)
+    related_tests = []
+    for test_dir in ("test", "tests", "spec", "e2e", "playwright", "cypress"):
+        p = repo_root / test_dir
+        if p.exists():
+            related_tests.append(test_dir)
+    return {
+        "packageManager": package_manager,
+        "framework": "nextjs" if has_dep("next") else "vite" if has_dep("vite") else "react" if has_dep("react") else "unknown",
+        "scripts": sorted(scripts.keys()),
+        "capabilities": {
+            "typescript": (repo_root / "tsconfig.json").exists(),
+            "vitest": has_dep("vitest"),
+            "jest": has_dep("jest"),
+            "playwright": has_dep("@playwright/test") or has_dep("playwright"),
+            "cypress": has_dep("cypress"),
+            "ci": any((repo_root / p).exists() for p in (".github/workflows", ".gitlab-ci.yml")),
+        },
+        "commands": commands,
+        "relatedTests": related_tests,
+    }
+
+
+def classify_task(task: str, explicit: str | None = None) -> str:
+    if explicit:
+        return explicit
+    t = task.lower()
+    if any(w in t for w in ("flaky", "flake", "race", "간헐", "불안정", "타이밍")):
+        return "flaky-test"
+    if any(w in t for w in ("refactor", "rename", "migration", "migrate", "mechanical", "리팩", "마이그레이션", "일괄")):
+        return "refactor"
+    if any(w in t for w in ("bug", "fix", "error", "fail", "broken", "버그", "수정", "실패", "오류", "안됨")):
+        return "bugfix"
+    return "unknown"
+
+
+def command_resolved(scan: dict[str, Any], key: str) -> bool:
+    return bool(scan.get("commands", {}).get(key, {}).get("run"))
+
+
+def select_recommendation(task_type: str, scan: dict[str, Any], forced_motif: str | None = None) -> tuple[str, str, str, list[str], int, str]:
+    unit = command_resolved(scan, "unit")
+    typecheck = command_resolved(scan, "typecheck")
+    targeted = command_resolved(scan, "targetedE2E") or unit
+    blockers: list[str] = []
+    if forced_motif:
+        if forced_motif not in VALID_MOTIFS:
+            raise SystemExit(f"unsupported motif: {forced_motif}")
+        motif = forced_motif
+    elif task_type in LOOP_MOTIFS:
+        motif = LOOP_MOTIFS[task_type]
+    else:
+        return "not-recommended", "not-recommended", "manual", ["task-type-unknown-or-manual"], 20, "low"
+    if task_type == "flaky-test" and not unit:
+        blockers.append("repeat-command-unresolved")
+    if task_type == "refactor" and not (unit or typecheck):
+        blockers.append("regression-verifier-unresolved")
+    if task_type == "bugfix" and not targeted:
+        blockers.append("targeted-verifier-unresolved")
+    if blockers:
+        return motif, "conditional", "incomplete", blockers, 55, "medium"
+    return motif, "recommended", "complete", [], 87, "medium"
+
+
+def targeted_command_ref(task_type: str, scan: dict[str, Any]) -> tuple[str, str]:
+    if task_type == "bugfix" and command_resolved(scan, "targetedE2E"):
+        return "repository.commands.targetedE2E", "resolved"
+    if task_type in {"bugfix", "refactor", "flaky-test"} and command_resolved(scan, "unit"):
+        return "repository.commands.unit", "resolved"
+    if command_resolved(scan, "typecheck"):
+        return "repository.commands.typecheck", "resolved"
+    return "repository.commands.targetedE2E", "unresolved"
+
+
+def context_fingerprint(repo_root: Path, scan: dict[str, Any]) -> dict[str, Any]:
+    head = git("rev-parse", "HEAD", cwd=repo_root) or "unknown"
+    changed, partial = collect_changed_paths(repo_root)
+    inputs: list[dict[str, Any]] = [{"headSha": head}, {"changed": changed}]
+    for rel in ("package.json", "tsconfig.json", ".github/workflows"):
+        p = repo_root / rel
+        if p.is_file():
+            digest, reason = safe_file_hash(p)
+            inputs.append({"path": rel, "contentHash": digest, "hashExcludedReason": reason})
+            if reason:
+                partial = True
+        elif p.is_dir():
+            for child in sorted(x for x in p.rglob("*") if x.is_file())[:50]:
+                rel_child = str(child.relative_to(repo_root))
+                digest, reason = safe_file_hash(child)
+                inputs.append({"path": rel_child, "contentHash": digest, "hashExcludedReason": reason})
+                if reason:
+                    partial = True
+    payload = json.dumps(inputs, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return {
+        "headSha": head,
+        "dirty": bool(git("status", "--porcelain", cwd=repo_root)),
+        "fingerprint": {
+            "algorithm": "tigerkit-worktree-v1",
+            "value": sha256_bytes(payload),
+            "coverage": "partial" if partial else "full",
+        },
+        "scannedAt": now_iso(),
+        "inputs": changed,
+    }
+
+
+def yaml_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if not text or any(c in text for c in ":#{}[]&,*?|-<>=!%@`\n") or text.lower() in {"null", "true", "false"}:
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def dump_yaml(value: Any, indent: int = 0) -> str:
+    sp = " " * indent
+    if isinstance(value, dict):
+        lines = []
+        for k, v in value.items():
+            if isinstance(v, (dict, list)):
+                lines.append(f"{sp}{k}:")
+                lines.append(dump_yaml(v, indent + 2))
+            else:
+                lines.append(f"{sp}{k}: {yaml_scalar(v)}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        if not value:
+            return f"{sp}[]"
+        lines = []
+        for item in value:
+            if isinstance(item, dict):
+                lines.append(f"{sp}-")
+                lines.append(dump_yaml(item, indent + 2))
+            elif isinstance(item, list):
+                lines.append(f"{sp}-")
+                lines.append(dump_yaml(item, indent + 2))
+            else:
+                lines.append(f"{sp}- {yaml_scalar(item)}")
+        return "\n".join(lines)
+    return f"{sp}{yaml_scalar(value)}"
+
+
+def motif_defaults(motif: str) -> tuple[str, dict[str, Any], dict[str, Any], list[str]]:
+    if motif == "inventory-batch-transform-verify":
+        return "fresh-per-batch", {"maxBatches": 12, "sameFailureLimit": 2}, {"batchSize": 5, "fullVerificationEveryBatches": 3}, ["public-export-change", "dependency-change", "snapshot-update", "inventory-query-weakening", "unrelated-change"]
+    if motif == "repeat-trace-classify-patch-stress":
+        return "retain-until-failure-class-changes", {"maxIterations": 4, "sameFailureLimit": 2}, {"initialRepeatCount": 20, "stressRepeatCount": 50}, ["retry-increase", "timeout-increase", "fixed-sleep", "test-skip", "assertion-or-selector-weakening"]
+    return "retain-until-hypothesis-reset", {"maxIterations": 4, "sameFailureLimit": 2}, {}, ["snapshot-update", "dependency-change", "test-skip", "assertion-weakening", "fixed-sleep", "unrelated-change"]
+
+
+def build_loop_spec(repo_root: Path, task: str, args: argparse.Namespace) -> tuple[dict[str, Any], Path | None]:
+    ensure_state_root_outside_repo(repo_root)
+    task = sanitize_task_text(task)
+    task_type = classify_task(task, args.type)
+    if args.motif and task_type != "unknown" and args.motif != LOOP_MOTIFS.get(task_type):
+        raise SystemExit("--type and --motif are incompatible")
+    scan = scan_capabilities(repo_root, task)
+    motif, applicability, readiness, blockers, fit, confidence = select_recommendation(task_type, scan, args.motif)
+    spec_id = next_loop_spec_id(args.name)
+    context = context_fingerprint(repo_root, scan)
+    context_policy, budget, params, forbids = motif_defaults(motif)
+    command_ref, command_resolution = targeted_command_ref(task_type, scan)
+    repo_key_value = repo_key(repo_root)
+    scope_key_value = scope_key(repo_root)
+    reasons = [
+        {"value": f"task-type-{task_type}", "provenance": "declared" if args.type else "assumed", "source": "--type" if args.type else "task-classifier"},
+        {"value": f"package-manager-{scan['packageManager']}", "provenance": "verified", "source": "package.json-or-lockfile"},
+    ]
+    if scan.get("relatedTests"):
+        reasons.append({"value": "test-directories-detected", "provenance": "verified", "source": ",".join(scan["relatedTests"])})
+    spec = {
+        "apiVersion": "tigerkit.dev/v1alpha1",
+        "kind": "LoopSpec",
+        "metadata": {
+            "id": spec_id,
+            "name": args.name or spec_id,
+            "generatedAt": now_iso(),
+            "tigerkitVersion": "0.x",
+            "schemaVersion": "v1alpha1",
+            "motifCatalogVersion": "v1",
+        },
+        "source": {"task": task, "origin": "slash-command"},
+        "worktree": {"repositoryId": repo_key_value, "scopeId": scope_key_value, "branch": git("branch", "--show-current", cwd=repo_root) or "detached-or-workspace"},
+        "context": context,
+        "task": {"type": task_type, "risk": "medium", "properties": {"reproducibility": "medium", "oracleStrength": "high" if scan.get("commands", {}).get("unit", {}).get("run") else "unresolved", "expectedScope": "local", "humanJudgmentDependency": "low"}},
+        "recommendation": {"motif": motif, "applicability": applicability, "fitScore": fit, "confidence": confidence, "reasons": reasons, "alternatives": []},
+        "readiness": {"status": readiness, "blockers": blockers},
+        "repository": {"packageManager": scan["packageManager"], "framework": scan["framework"], "capabilities": scan["capabilities"], "commands": scan["commands"]},
+        "loop": {"contextPolicy": context_policy, "parameters": params, "steps": [
+            {"id": "reproduce" if motif != "inventory-batch-transform-verify" else "inventory", "type": "agent", "objective": "Confirm the working set or failing reproduction."},
+            {"id": "patch" if motif != "inventory-batch-transform-verify" else "transform", "type": "agent", "objective": "Apply the smallest safe change for the selected batch or hypothesis."},
+            {"id": "targeted-verification", "type": "command", "commandRef": command_ref, "required": True, "resolution": command_resolution},
+            {"id": "regression-verification", "type": "command", "commandRefs": ["repository.commands.typecheck", "repository.commands.unit"]},
+            {"id": "review", "type": "manual-checkpoint", "checks": ["no-test-weakening", "no-unrelated-changes", "root-cause-addressed"]},
+        ]},
+        "guards": {"maxChangedFiles": 5, "forbid": forbids},
+        "budget": budget,
+        "success": {"all": ["targeted-verification-passed", "regression-verification-passed", "diff-review-passed"]},
+        "escalate": {"any": ["reproduction-not-obtained", "public-api-change-required", "same-failure-limit-reached", "required-verifier-unresolved"]},
+        "evidence": {"required": ["root-cause", "before-after-proof", "changed-files", "verification-log"]},
+    }
+    path = None if args.no_write else loop_spec_dir(repo_root, spec_id) / "spec.yaml"
+    return spec, path
+
+
+def render_loop_spec_summary(spec: dict[str, Any], path: Path | None) -> str:
+    rec = spec["recommendation"]
+    readiness = spec["readiness"]
+    lines = [
+        f"Loop strategy: {rec['motif']}",
+        f"Applicability: {rec['applicability']}",
+        f"Readiness: {readiness['status']}",
+        f"Fit score: {rec['fitScore']}/100",
+        f"Confidence: {rec['confidence']}",
+        f"Worktree: {spec['worktree']['branch']}",
+        "",
+        "Why",
+    ]
+    for reason in rec.get("reasons", []):
+        lines.append(f"  - {reason['value']} ({reason['provenance']})")
+    lines += ["", "Blockers"]
+    for blocker in readiness.get("blockers") or ["NONE"]:
+        lines.append(f"  - {blocker}")
+    lines += ["", "Guards"]
+    for guard in spec["guards"]["forbid"]:
+        lines.append(f"  - No {guard}")
+    lines += ["", "Saved"]
+    lines.append(f"  {path if path else 'NONE (--no-write)'}")
+    lines += ["", "Write receipt", f"  changed: {path if path else 'NONE'}", "  source tree changed: no"]
+    return "\n".join(lines)
+
+
+def update_loop_branch_state(repo_root: Path, spec: dict[str, Any], path: Path) -> None:
+    branch_state_path = state_root() / "repos" / repo_key(repo_root) / "branches" / scope_key(repo_root) / "branch-state.json"
+    branch_state = load_json(branch_state_path, {})
+    branch_state.update({
+        "repoKey": repo_key(repo_root),
+        "scopeKey": scope_key(repo_root),
+        "lastLoopSpecId": spec["metadata"]["id"],
+        "lastLoopSpecPath": str(path),
+        "updatedAt": now_iso(),
+    })
+    atomic_write_json(branch_state_path, branch_state)
+
+
+def cmd_loop_spec(args: argparse.Namespace) -> int:
+    repo_root = resolve_repo_root(args.repo_root)
+    task_args = list(args.task or [])
+    if task_args and task_args[0] == "validate":
+        if len(task_args) != 2:
+            raise SystemExit("Usage: loop-spec validate <spec-id-or-path>")
+        args.spec = task_args[1]
+        return cmd_loop_spec_validate(args, repo_root)
+    task = " ".join(task_args).strip()
+    if not task:
+        raise SystemExit("/tk:loop-spec generate requires a task. Usage: loop-spec '<task>'")
+    spec, path = build_loop_spec(repo_root, task, args)
+    if path:
+        atomic_write(path, dump_yaml(spec) + "\n")
+        update_loop_branch_state(repo_root, spec, path)
+    print(render_loop_spec_summary(spec, path))
+    if args.explain:
+        print("\nExplain")
+        print(f"  context fingerprint coverage: {spec['context']['fingerprint']['coverage']}")
+        print("  selector mode: rules")
+        print("  command discovery is separated from execution status")
+    return 0
+
+
+def resolve_loop_spec_path(repo_root: Path, spec_id_or_path: str) -> Path:
+    p = Path(spec_id_or_path).expanduser()
+    if p.exists() or p.is_absolute() or "/" in spec_id_or_path:
+        return p.resolve()
+    return loop_spec_dir(repo_root, spec_id_or_path) / "spec.yaml"
+
+
+def read_yamlish_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except Exception as exc:
+        raise SystemExit(f"cannot read LoopSpec: {path}: {exc}") from exc
+
+
+def extract_yaml_string(text: str, key: str) -> str | None:
+    m = re.search(rf"^\s*{re.escape(key)}:\s*(.+?)\s*$", text, re.M)
+    if not m:
+        return None
+    raw = m.group(1).strip()
+    if raw.startswith('"') and raw.endswith('"'):
+        try:
+            return json.loads(raw)
+        except Exception:
+            return raw.strip('"')
+    return None if raw == "null" else raw
+
+
+def cmd_loop_spec_validate(args: argparse.Namespace, repo_root: Path) -> int:
+    path = resolve_loop_spec_path(repo_root, args.spec)
+    text = read_yamlish_text(path)
+    required_tokens = ["apiVersion:", "kind: LoopSpec", "metadata:", "recommendation:", "readiness:", "context:", "fingerprint:"]
+    missing = [tok for tok in required_tokens if tok not in text]
+    schema = "invalid" if missing else "valid"
+    stored_head = extract_yaml_string(text, "headSha")
+    current_head = git("rev-parse", "HEAD", cwd=repo_root)
+    context = "unknown"
+    if stored_head and current_head:
+        context = "current" if stored_head == current_head else "stale"
+    print(f"LoopSpec: {path}")
+    print(f"Schema: {schema}")
+    print(f"Context: {context}")
+    if missing:
+        print("Missing")
+        for item in missing:
+            print(f"  - {item}")
+    if context == "stale":
+        print("Recommendation")
+        print("  Regenerate with /tk:loop-spec <task>")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="TigerKit generated state helpers")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -160,6 +632,16 @@ def build_parser() -> argparse.ArgumentParser:
     p_write.add_argument("--gap-id", help="Explicit GAP id", default=None)
     p_write.add_argument("--report-file", help="Read report content from file instead of stdin", default=None)
     p_write.set_defaults(func=cmd_write_gap)
+
+    p_loop = sub.add_parser("loop-spec", help="Generate or validate a worktree-scoped LoopSpec")
+    p_loop.add_argument("--repo-root", help="Repo root or working directory", default=None)
+    p_loop.add_argument("--explain", action="store_true", help="Include expanded explanation in command output")
+    p_loop.add_argument("--type", choices=["bugfix", "refactor", "flaky-test"], default=None, help="Override deterministic task classifier")
+    p_loop.add_argument("--motif", choices=sorted(VALID_MOTIFS), default=None, help="Force a motif when policy allows it")
+    p_loop.add_argument("--name", default=None, help="Human-friendly spec name")
+    p_loop.add_argument("--no-write", action="store_true", help="Render recommendation without writing an artifact")
+    p_loop.add_argument("task", nargs="*", help="Task description, or: validate <spec-id-or-path>")
+    p_loop.set_defaults(func=cmd_loop_spec)
     return parser
 
 


### PR DESCRIPTION
## 요약
- 이슈: RFC v5의 `/tk:loop-spec` public command를 TigerKit core command surface에 추가합니다.
- 수정: 명시적 task를 read-only worktree scan 기반 `LoopSpec` recommendation으로 생성/검증하는 helper와 command contract를 추가하고, plugin/marketplace/README/docs/evals를 동기화했습니다.
- 검증: plugin manifest validation, marketplace validation, JSON validation, plugin version invariant, helper smoke tests를 통과했습니다.

## 주요 변경
- `/tk:loop-spec "<task>"` 및 `/tk:loop-spec validate <spec-id-or-path>` command contract 추가
- `scripts/tigerkit_state.py loop-spec` helper 추가
  - deterministic task classification
  - curated MVP motif selection
  - `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/loop-specs/<spec-id>/spec.yaml` write
  - `--no-write`, `--explain`, `--type`, `--motif`, `--name`
  - context fingerprint and freshness validation
- raw diff/secret content 저장 방지
- command discovery와 execution probe metadata 분리
- `/tk:gap`, `/tk:reflect`, `/tk:loop-spec` public surface 문서/manifest/eval 동기화
- plugin version bump: `16.0.0`

## 검증
- `python3 -m py_compile scripts/tigerkit_state.py`
- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .`
- `git diff --check`
- `python3 -m json.tool evals/evals.json >/dev/null`
- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- `python3 scripts/check-plugin-version.py`
- smoke: temp `TIGERKIT_STATE_ROOT`에서 loop-spec generate/write 확인
- smoke: `--no-write`가 artifact를 만들지 않음 확인
- smoke: validate가 `Schema: valid`, `Context: current` 출력 확인
- smoke: generated spec에 raw diff token과 secret value가 저장되지 않음 확인
- smoke: repo 내부 `TIGERKIT_STATE_ROOT`는 guard로 거절 확인

## 참고
- `yarn` binary는 현재 실행 환경에 없어 `yarn validate` 대신 package.json의 direct validation chain을 실행했습니다.
- 실제 runner/autopilot/approval lifecycle은 포함하지 않습니다.
