### PR TITLE
fix: return loop-spec usage for empty input

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "SoT가 있으면 gap을 먼저 고려하고, 작업 후 reflect로 학습을 남기며, 명시적 task는 loop-spec으로 추천 계약을 생성하는 hook-free TigerKit Claude Code 플러그인입니다.",
-  "version": "16.0.3",
+  "version": "16.0.4",
   "author": {
     "name": "MTGVim"
   },

--- a/commands/loop-spec.md
+++ b/commands/loop-spec.md
@@ -102,6 +102,8 @@ python3 "$TIGERKIT_STATE_SCRIPT" loop-spec $ARGUMENTS
 
 `/Users/.../<current-repo>/scripts/tigerkit_state.py` 같은 현재 repo 상대경로를 가정하면 안 됩니다. `CLAUDE_PLUGIN_ROOT`가 비어 있거나 versioned install cache가 아닐 수도 있으므로, helper를 찾지 못하면 blocker를 보고하고 LoopSpec을 invent하지 않습니다.
 
+If the user invokes `/tk:loop-spec` with no task, or types bare `validate` without `<spec-id-or-path>`, return concise usage/help text and examples instead of surfacing a raw shell error.
+
 ## Output contract
 
 기본 출력은 아래 정보를 포함해야 합니다.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -578,6 +578,8 @@
       ],
       "expectations": [
         "Explicit /tk:loop-spec trigger only",
+        "No-task invocation returns usage/help instead of raw shell error",
+        "Bare validate without spec id returns usage/help instead of raw shell error",
         "Generates LoopSpec under ~/.tigerkit loop-specs path",
         "Validate reports schema and context freshness",
         "Does not mutate source tree",

--- a/scripts/tigerkit_state.py
+++ b/scripts/tigerkit_state.py
@@ -544,17 +544,33 @@ def update_loop_branch_state(repo_root: Path, spec: dict[str, Any], path: Path) 
     atomic_write_json(branch_state_path, branch_state)
 
 
+def render_loop_spec_usage() -> str:
+    return "\n".join([
+        "사용법: /tk:loop-spec \"<task>\"",
+        "또는: /tk:loop-spec validate <spec-id-or-path>",
+        "",
+        "예:",
+        '  /tk:loop-spec "Fix payment modal scroll bug"',
+        "  /tk:loop-spec validate <spec-id-or-path>",
+    ])
+
+
 def cmd_loop_spec(args: argparse.Namespace) -> int:
     repo_root = resolve_repo_root(args.repo_root)
     task_args = list(args.task or [])
+    if not task_args:
+        print(render_loop_spec_usage())
+        return 0
     if task_args and task_args[0] == "validate":
         if len(task_args) != 2:
-            raise SystemExit("Usage: loop-spec validate <spec-id-or-path>")
+            print(render_loop_spec_usage())
+            return 0
         args.spec = task_args[1]
         return cmd_loop_spec_validate(args, repo_root)
     task = " ".join(task_args).strip()
     if not task:
-        raise SystemExit("/tk:loop-spec generate requires a task. Usage: loop-spec '<task>'")
+        print(render_loop_spec_usage())
+        return 0
     spec, path = build_loop_spec(repo_root, task, args)
     if path:
         atomic_write(path, dump_yaml(spec) + "\n")


### PR DESCRIPTION
## 요약
- 이슈: `/tk:loop-spec`를 task 없이 호출하면 raw helper error가 surfaced되던 문제
- 수정: no-task / bare `validate` 입력은 usage/help를 출력하고 `exit 0`으로 처리
- 검증: helper 직접 실행 기준 no-task, bare validate 모두 usage/help 출력 + exit 0

## 문제
기존 helper는 다음처럼 처리했습니다.

```text
/tk:loop-spec generate requires a task. Usage: loop-spec '<task>'
```

그래서 command surface에서 그대로 실행되면 shell error처럼 보였습니다.

## 수정
- `scripts/tigerkit_state.py`
- `commands/loop-spec.md`
- `evals/evals.json`
- `.claude-plugin/plugin.json` version `16.0.4`

새 동작:
- `/tk:loop-spec` → usage/help 출력, `exit 0`
- `/tk:loop-spec validate` → usage/help 출력, `exit 0`
- 실제 validate 실패(`missing spec` 등)는 여전히 error 유지

## 검증
- [x] `python3 -m json.tool evals/evals.json >/dev/null`
- [x] `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- [x] `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- [x] `git diff --check`
- [x] `claude plugin validate .claude-plugin/plugin.json`
- [x] `claude plugin validate .`
- [x] `python3 scripts/check-plugin-version.py`
- [x] `python3 scripts/tigerkit_state.py loop-spec` -> usage/help, exit 0
- [x] `python3 scripts/tigerkit_state.py loop-spec validate` -> usage/help, exit 0
