### PR TITLE
docs(ui-diff): add cdp-direct driver guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "SoT gap, route, reflect, ui-diff와 grill/prototype/merge-conflict/handoff/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다.",
-  "version": "16.4.0",
+  "version": "16.4.1",
   "author": {
     "name": "MTGVim"
   },

--- a/skills/ui-diff/SKILL.md
+++ b/skills/ui-diff/SKILL.md
@@ -47,6 +47,19 @@ tracked repo에는 credential을 직접 커밋하지 않습니다.
 1. MCP driver가 있으면 사용할 수 있습니다.
 2. 없으면 `cdp-direct` fallback으로 진행할 수 있어야 합니다.
 3. 특정 driver가 필수라는 가정을 두지 않습니다.
+4. CDP-direct 실행 레시피는 `references/drivers/cdp-direct.md`를 참조합니다.
+
+## Driver-agnostic techniques
+
+- 입력 주입(React 등): controlled input은 `el.value` 직접 대입이 안 먹을 수 있으므로 native value setter로 값을 넣고 `input`/`change` 이벤트를 dispatch합니다.
+- 클릭: programmatic `element.click()`만으로는 프레임워크 핸들러를 신뢰성 있게 깨우지 못할 수 있으므로 실제 마우스 이벤트(press + release 좌표 클릭)를 우선합니다.
+- 뷰포트 밖 요소: 음수 y 또는 y > viewport height면 좌표 클릭이 무효가 될 수 있으므로 `scrollIntoView({block:'center'})` 후 rect를 다시 구합니다.
+- 클릭 가로챔: 클릭이 안 먹으면 `document.elementFromPoint(x,y)`로 위에 겹친 요소(sticky, 캐러셀 등)를 확인합니다.
+- 오버레이 종류 구분: 라이브러리 모달(예: Radix Dialog)은 `[role=dialog]`를 가질 수 있지만 커스텀 `div` 오버레이는 없을 수 있으므로 특정 프레임워크를 가정하지 않고 존재 여부로 판별합니다.
+- scroll-lock 부작용: `body overflow:hidden`이 스크롤바를 제거하면 중앙정렬 기준폭이 스크롤바 폭만큼 넓어져 콘텐츠가 그 절반만큼 수평 이동할 수 있습니다. 폭 변화가 아니라 위치 시프트로 해석해야 합니다.
+- 측정 기준: “비슷해 보이면 OK”로 끝내지 않고 computed style과 bounding rect를 px/hex/opacity 기준으로 대조하고, 다른 값만 보고합니다.
+- HMR: dev 서버가 Fast Refresh를 지원하면 컴포넌트/모달 상태가 유지될 수 있으므로 고친 뒤 재오픈 없이 재측정할 수 있습니다. 닫혔으면 다시 엽니다.
+- Driver: MCP driver(playwright/chrome-devtools 등)가 있으면 사용하고, 없으면 CDP-direct로 폴백합니다. 특정 driver를 필수로 가정하지 않습니다.
 
 ## Feedback loop
 

--- a/skills/ui-diff/references/drivers/cdp-direct.md
+++ b/skills/ui-diff/references/drivers/cdp-direct.md
@@ -1,0 +1,71 @@
+# Driver: CDP-direct (raw Chrome DevTools Protocol)
+
+MCP driver가 없을 때(예: 세션에서 MCP가 로드 안 됨)의 폴백. 크롬을 원격 디버깅으로 띄우고 CDP를 직접 두드린다. 어떤 FE web 프로젝트에도 동일하게 적용된다. 코드는 표준 JS라 그대로 이식된다.
+
+## 러너 (환경 치환 가능)
+
+아래 JS를 실행할 수단은 환경마다 다르다 — **가용한 것을 쓴다**:
+- `ctx_execute`(context-mode 플러그인이 있으면) — HTTP/WebSocket 허용
+- `node`(Node 18+; 전역 `fetch`·`WebSocket` 있음)
+- 기타 JS 런타임
+스크린샷은 **파일 쓰기가 되는 러너**(예: node) 필요. sandbox 러너는 host 파일 저장이 안 될 수 있다.
+
+## 크롬 기동 (OS별 실행 경로)
+
+```
+<chrome-binary> --remote-debugging-port=9222 --user-data-dir="<debug-profile-dir>" \
+  --window-size=<viewport> "<baseline_url>" "<target_url>"
+```
+- 포트 9222는 관례(설정 가능). `<chrome-binary>`는 OS별 경로(macOS: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`).
+
+## 헬퍼 (JS, 매 실행 재정의)
+
+```javascript
+// 단일 CDP 명령
+function cdp(w,method,params={}){return new Promise((res,rej)=>{const ws=new WebSocket(w);ws.onopen=()=>ws.send(JSON.stringify({id:1,method,params}));ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.id===1){ws.close();m.error?rej(m.error):res(m.result);}};ws.onerror=e=>rej(String(e));setTimeout(()=>{try{ws.close()}catch{};rej("t")},9000);});}
+// 페이지 JS 평가 (returnByValue)
+function ev(w,expr){return new Promise((res,rej)=>{const ws=new WebSocket(w);ws.onopen=()=>ws.send(JSON.stringify({id:1,method:"Runtime.evaluate",params:{expression:expr,returnByValue:true,awaitPromise:true}}));ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.id===1){ws.close();m.result?.exceptionDetails?rej(JSON.stringify(m.result.exceptionDetails).slice(0,300)):res(m.result.result.value);}};ws.onerror=e=>rej(String(e));setTimeout(()=>{try{ws.close()}catch{};rej("t")},9000);});}
+// 여러 명령 배치 (실제 마우스 클릭용)
+function rpc(w,msgs){return new Promise((res)=>{const ws=new WebSocket(w);let i=0;const r={};ws.onopen=()=>msgs.forEach(m=>ws.send(JSON.stringify(m)));ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.id){r[m.id]=m.result||m.error;i++;if(i>=msgs.length){ws.close();res(r);}}};ws.onerror=()=>res(r);setTimeout(()=>{try{ws.close()}catch{};res(r);},9000);});}
+const sleep=ms=>new Promise(r=>setTimeout(r,ms));
+const clickXY=(w,x,y)=>rpc(w,[{id:1,method:"Input.dispatchMouseEvent",params:{type:"mousePressed",x,y,button:"left",clickCount:1}},{id:2,method:"Input.dispatchMouseEvent",params:{type:"mouseReleased",x,y,button:"left",clickCount:1}}]);
+// 열린 탭 목록 (webSocketDebuggerUrl 획득). PAGE_ID = 그 URL의 마지막 segment
+const tabs=async()=>(await (await fetch("http://127.0.0.1:9222/json")).json()).filter(t=>t.type==="page");
+```
+
+## 입력 주입 (native setter)
+
+```javascript
+const set=(el,v)=>{const s=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set;s.call(el,v);el.dispatchEvent(new Event('input',{bubbles:true}));el.dispatchEvent(new Event('change',{bubbles:true}));};
+```
+
+## 클릭 (실제 마우스 이벤트 + 뷰포트 보정)
+
+```javascript
+const el=await ev(w,`(()=>{const e=document.querySelector('<sel>');if(!e)return null;e.scrollIntoView({block:'center'});const r=e.getBoundingClientRect();return JSON.stringify({x:Math.round(r.x+r.width/2),y:Math.round(r.y+r.height/2)});})()`);
+const {x,y}=JSON.parse(el); await sleep(500); await clickXY(w,x,y);
+```
+
+## 측정 (예시 heuristic — 대상에 맞게 셀렉터 조정)
+
+```javascript
+const measure=`(()=>{const vw=innerWidth,vh=innerHeight;
+  const dark=[...document.querySelectorAll('div')].filter(d=>{const r=d.getBoundingClientRect();const s=getComputedStyle(d);return r.width>vw*0.9&&r.height>vh*0.9&&s.backgroundColor.includes('0, 0, 0')&&s.backgroundColor!=='rgba(0, 0, 0, 0)';}).map(d=>{const s=getComputedStyle(d);return {bg:s.backgroundColor,op:s.opacity,cls:(d.className||'').toString().slice(0,32)};});
+  const img=[...document.querySelectorAll('img')].sort((a,b)=>b.getBoundingClientRect().width-a.getBoundingClientRect().width)[0];
+  let card=null;if(img){let el=img;for(let i=0;i<8&&el;i++){const s=getComputedStyle(el),r=el.getBoundingClientRect();if(s.backgroundColor.includes('255, 255, 255')&&r.width>200){card={w:Math.round(r.width),x:Math.round(r.x)};break;}el=el.parentElement;}}
+  return JSON.stringify({vw,vh,dark,imgW:img?Math.round(img.getBoundingClientRect().width):null,card});
+})()`;
+```
+prop 후보: width/height, padding/margin, background-color, opacity, border, border-radius, font-size, color, z-index, getBoundingClientRect.
+
+## 스크린샷 (파일 쓰기 되는 러너, 예: node)
+
+```
+node -e '
+const WS="ws://127.0.0.1:9222/devtools/page/<PAGE_ID>";const fs=require("fs");const ws=new WebSocket(WS);let id=0;const p={};
+const send=(m,pa={})=>new Promise((r)=>{const i=++id;p[i]=r;ws.send(JSON.stringify({id:i,method:m,params:pa}));});
+ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.id&&p[m.id]){p[m.id](m.result);delete p[m.id];}};
+ws.onopen=async()=>{await send("Page.enable");const r=await send("Page.captureScreenshot",{format:"png"});fs.writeFileSync("shot.png",Buffer.from(r.data,"base64"));ws.close();process.exit(0);};
+'
+```
+- OS 임시폴더 권한으로 외부에서 만든 스크린샷 파일을 못 읽을 수 있으니, 위처럼 CDP로 직접 캡처해 접근 가능한 경로에 저장.

--- a/skills/ui-diff/references/modes/env-diff.md
+++ b/skills/ui-diff/references/modes/env-diff.md
@@ -16,6 +16,16 @@ env-diff는 QA/runtime와 local/runtime를 같은 화면, 같은 context, 같은
 - color/opacity/background
 - scroll-lock / centering side effect
 
+## Procedure
+
+1. local dev 서버를 확인하거나 기동합니다. profile `env.md`의 local_dev_cmd, tailwind bootstrap, local_url을 기준으로 맞춥니다.
+2. baseline_url과 target_url 두 탭을 같은 viewport로 엽니다. driver는 MCP 또는 cdp-direct를 사용합니다.
+3. 탭을 식별합니다. baseline은 qa_url 도메인, target은 local_url 기준으로 구분합니다.
+4. 로그인합니다. 기법은 엔진의 driver-agnostic 규칙을 따르고, 셀렉터와 자격 정보는 profile `login.md`와 `login.local.md`에서 읽습니다. 필요한 컨텍스트 전환도 profile 기준으로 처리합니다.
+5. 대상 화면으로 진입합니다. 화면 정의는 profile `screens/<name>.md`를 따르고, 클릭은 실제 마우스 이벤트 기준으로 수행합니다.
+6. 양쪽 탭에서 측정합니다. prop diff를 만들고 다른 값만 보고합니다.
+7. 필요하면 스크린샷을 추가해 위치와 육안 차이를 보조 증거로 남깁니다.
+
 ## Notes
 
 - 스크린샷은 보조 증거일 뿐이고, 핵심 결론은 computed evidence를 기준으로 둡니다.

--- a/support/execute-support-matrix.json
+++ b/support/execute-support-matrix.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "tigerkit.execute-support-matrix/v1",
-  "pluginVersion": "16.4.0",
-  "generatedAt": "2026-07-02T22:17:08Z",
+  "pluginVersion": "16.4.1",
+  "generatedAt": "2026-07-03T00:34:50Z",
   "environments": [
     {
       "environmentKey": "claude-code/linux/local/default",


### PR DESCRIPTION
## 요약
- 이슈: #140 `skills/ui-diff/` 엔진에 driver-agnostic 실행 상세가 없어 MCP 없는 세션에서 executable 절차가 비어 있던 문제
- 수정: `skills/ui-diff/SKILL.md`에 driver-agnostic 기법을 추가하고, `references/drivers/cdp-direct.md`에 raw CDP 폴백 절차를 추가하고, `references/modes/env-diff.md`에 env-diff 실행 순서를 보강했습니다.
- 검증: `claude plugin validate .claude-plugin/plugin.json`, `claude plugin validate .`, `python3 scripts/check-plugin-version.py`, `git diff --check` 통과

## 변경 내용
- 엔진 본문에 입력 주입, 실제 마우스 클릭, scroll-lock 해석, 측정 기준, HMR, driver fallback 원칙을 추가했습니다.
- 새 `skills/ui-diff/references/drivers/cdp-direct.md`에 raw CDP helper / 입력 주입 / 클릭 / 측정 / 스크린샷 절차를 추가했습니다.
- `env-diff` 모드 문서에 local dev 확인 → 두 탭 오픈 → 탭 식별 → 로그인 → 화면 진입 → 측정 → 스크린샷의 실행 순서를 추가했습니다.
- 플러그인 패치 버전을 `16.4.1`로 올리고 support matrix 버전도 같이 맞췄습니다.

## 검증
- `claude plugin validate .claude-plugin/plugin.json`
- `claude plugin validate .`
- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- `python3 -m json.tool evals/evals.json >/dev/null`
- `python3 scripts/check-plugin-version.py`
- `git diff --check`

Closes #140
