### PR TITLE
docs: improve compact output readability guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "SoT gap, route, reflect, learn, browser-verify와 grill/grooming/prototype/merge-conflict/handoff/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다.",
-  "version": "16.5.8",
+  "version": "16.5.9",
   "author": {
     "name": "MTGVim"
   },

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -13,6 +13,8 @@
 - Active command surface는 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:to-prd`, `/tk:to-issues`, `/tk:browser-verify`입니다.
 - 기본 projection은 compact합니다. empty section, default empty list, `NONE` line은 의미 보존에 필요할 때만 출력합니다.
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact를 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 
 ## `/tk:gap` Output Contract
 

--- a/commands/arch-review.md
+++ b/commands/arch-review.md
@@ -36,6 +36,8 @@ skills/arch-review/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/browser-verify.md
+++ b/commands/browser-verify.md
@@ -102,6 +102,8 @@ skills/browser-verify/templates/screens/README.md -> ~/.tigerkit/repos/<repo-key
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/grill.md
+++ b/commands/grill.md
@@ -45,6 +45,8 @@ skills/grill/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/grooming.md
+++ b/commands/grooming.md
@@ -71,6 +71,8 @@ user | repo | all
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -49,6 +49,8 @@ skills/handoff/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -60,6 +60,8 @@ host가 다른 user skill surface를 지원하면 equivalent host-native user sk
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/merge-conflict.md
+++ b/commands/merge-conflict.md
@@ -29,6 +29,8 @@ skills/merge-conflict/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/prototype.md
+++ b/commands/prototype.md
@@ -32,6 +32,8 @@ skills/prototype/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -239,6 +239,8 @@ Rules:
 
 - stdout은 `요약 + ledger path + 다음 행동` 구조를 따릅니다.
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - stdout은 가능하면 target boundary를 짧게 드러냅니다.
 - `repo-local`, `user-global`은 direct-apply candidate, `skill`은 explicit materialize only, `repo-shared|hook|command|agent`는 suggest-only로 보이게 유지합니다.
 - reject/failure는 silent skip이 아니라 compact receipt에 `reason_code` 또는 동등한 reject 이유를 남깁니다.

--- a/commands/route.md
+++ b/commands/route.md
@@ -50,6 +50,8 @@ route = explicit task + current constraints -> compare implementation routes -> 
 기본 출력은 아래 정보를 포함해야 합니다.
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/to-issues.md
+++ b/commands/to-issues.md
@@ -34,6 +34,8 @@ skills/to-issues/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text

--- a/commands/to-prd.md
+++ b/commands/to-prd.md
@@ -34,6 +34,8 @@ skills/to-prd/SKILL.md
 ## Output contract
 
 - section label은 항상 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
 - optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
 
 ```text


### PR DESCRIPTION
## 요약
- TigerKit output contract에 compact는 유지하면서 읽힘을 높이는 가이드 추가
- section 사이 한 줄 여백 허용 규칙 추가
- 긴 설명은 bullet을 쪼개 한 줄에 한 뜻만 남기도록 정리
- 공통 owner와 sibling command contract 문구를 함께 정렬
- plugin version을 `16.5.9`로 패치 bump

## 검증
- [x] `python3 scripts/check-plugin-version.py`
- [x] `yarn validate`
