### PR TITLE
chore: prepare TigerKit patch release 16.5.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "MTGVim"
   },
   "metadata": {
-    "description": "SoT gap, route, reflect, learn, browser-verify와 grill/prototype/merge-conflict/handoff/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다."
+    "description": "SoT gap, route, reflect, learn, browser-verify와 grill/prototype/merge-conflict/handoff/handon/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다."
   },
   "plugins": [
     {
       "name": "tk",
       "source": "./",
-      "description": "SoT gap, route, reflect, learn, browser-verify와 grill/grooming/prototype/merge-conflict/handoff/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다. active command surface는 /tk:gap, /tk:route, /tk:reflect, /tk:learn, /tk:browser-verify, /tk:grill, /tk:grooming, /tk:prototype, /tk:arch-review, /tk:merge-conflict, /tk:handoff, /tk:to-prd, /tk:to-issues 입니다."
+      "description": "SoT gap, route, reflect, learn, browser-verify와 grill/grooming/prototype/merge-conflict/handoff/handon/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다. active command surface는 /tk:gap, /tk:route, /tk:reflect, /tk:learn, /tk:browser-verify, /tk:grill, /tk:grooming, /tk:prototype, /tk:arch-review, /tk:merge-conflict, /tk:handoff, /tk:handon, /tk:to-prd, /tk:to-issues 입니다."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
-  "description": "SoT gap, route, reflect, learn, browser-verify와 grill/grooming/prototype/merge-conflict/handoff/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다.",
-  "version": "16.5.12",
+  "description": "SoT gap, route, reflect, learn, browser-verify와 grill/grooming/prototype/merge-conflict/handoff/handon/to-prd/to-issues/arch-review를 제공하는 TigerKit Claude Code 플러그인입니다.",
+  "version": "16.5.13",
   "author": {
     "name": "MTGVim"
   },
@@ -16,6 +16,7 @@
     "./commands/prototype.md",
     "./commands/merge-conflict.md",
     "./commands/handoff.md",
+    "./commands/handon.md",
     "./commands/to-prd.md",
     "./commands/to-issues.md",
     "./commands/arch-review.md"

--- a/.tigerkit/docs/output-contract.md
+++ b/.tigerkit/docs/output-contract.md
@@ -10,7 +10,7 @@
 - Evidence, Interpretation, Decision, Suggestion을 구분합니다.
 - 검증하지 않은 success를 선언하지 않습니다.
 - command가 파일을 쓰면 changed path 또는 ledger path를 출력합니다.
-- Active command surface는 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:to-prd`, `/tk:to-issues`, `/tk:browser-verify`입니다.
+- Active command surface는 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:handon`, `/tk:to-prd`, `/tk:to-issues`, `/tk:browser-verify`입니다.
 - 기본 projection은 compact합니다. empty section, default empty list, `NONE` line은 의미 보존에 필요할 때만 출력합니다.
 - section label은 항상 `🎯 Goal:`처럼 leading emoji를 붙인 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
 - 같은 역할의 label은 가능하면 같은 emoji를 재사용합니다.
@@ -366,6 +366,26 @@ Handoff 완료 | Handoff 미리보기 | Handoff 중단
 - <verified / partially verified / unverified>
 ▶️ Next step:
 - <what the next agent should do first>
+```
+
+## `/tk:handon` Output Contract
+
+`/tk:handon`은 현재 repo/worktree의 저장된 current-first handoff를 repo-scoped `~/.tigerkit` root 아래에서 다시 읽는 read-only surface입니다.
+
+```text
+Handon 읽기 완료 | Handon 경로 확인 | Handon 없음
+📁 Handoff path:
+- <path>
+[📝 Focus:
+- <focus or question>]
+📝 Source:
+- current repo/worktree handoff artifact
+[📝 Summary:
+- <compact summary from saved handoff>]
+[⚠️ Missing:
+- no current handoff draft found]
+▶️ Next step:
+- <resume from remaining tasks | create a new handoff with /tk:handoff>
 ```
 
 ## `/tk:to-prd` Output Contract

--- a/.tigerkit/docs/usage.md
+++ b/.tigerkit/docs/usage.md
@@ -9,7 +9,7 @@
 ## 핵심 모델
 
 ```text
-TigerKit = gap + route + reflect + learn + grill + grooming + prototype + arch-review + merge-conflict + handoff + to-prd + to-issues + browser-verify
+TigerKit = gap + route + reflect + learn + grill + grooming + prototype + arch-review + merge-conflict + handoff + handon + to-prd + to-issues + browser-verify
 ```
 
 - `gap`: SoT와 Current Implementation의 차이를 한 번 분석합니다. evidence-first로 읽고 source conflict나 근거 부족은 `ambiguous`로 남깁니다.
@@ -22,11 +22,12 @@ TigerKit = gap + route + reflect + learn + grill + grooming + prototype + arch-r
 - `arch-review`: boundary, ownership, coupling, 반복 마찰을 evidence-first로 검토하는 report-only architecture review입니다.
 - `merge-conflict`: merge/rebase conflict를 ours/theirs intent 기준으로 해결합니다.
 - `handoff`: 다음 세션이나 다른 에이전트가 바로 이어받을 수 있는 handoff를 만듭니다.
+- `handon`: 현재 repo/worktree의 저장된 handoff를 다시 읽습니다.
 - `to-prd`: 현재 대화나 요구사항을 draft-only PRD로 정리합니다.
 - `to-issues`: plan/PRD를 independently grabbable vertical-slice issue draft로 분해합니다.
 - `browser-verify`: 번들된 browser-verify 엔진 skill을 현재 repo에 대응하는 `~/.tigerkit/repos/<repo-key>/browser-verify/` profile과 함께 사용하는 direct QA / behavior verification surface입니다.
 
-TigerKit은 일반 autopilot 또는 sealed workflow engine이 아니라 gap, route, reflect, learn, grill, grooming, prototype, arch-review, merge-conflict, handoff, to-prd, to-issues, browser-verify 중심의 가벼운 surface를 제공합니다.
+TigerKit은 일반 autopilot 또는 sealed workflow engine이 아니라 gap, route, reflect, learn, grill, grooming, prototype, arch-review, merge-conflict, handoff, handon, to-prd, to-issues, browser-verify 중심의 가벼운 surface를 제공합니다.
 
 ## Core guidance
 
@@ -42,6 +43,7 @@ TigerKit은 일반 autopilot 또는 sealed workflow engine이 아니라 gap, rou
 - `/tk:arch-review`는 evidence-first 구조 리뷰 surface입니다.
 - `/tk:merge-conflict`는 conflict 해결 전용 surface입니다.
 - `/tk:handoff`는 repo-scoped `~/.tigerkit` root 아래 worktree-scoped current-first handoff 생성 surface입니다.
+- `/tk:handon`은 repo-scoped `~/.tigerkit` root 아래 worktree-scoped current-first handoff read surface입니다.
 - `/tk:to-prd`는 draft-only PRD 생성 surface입니다.
 - `/tk:to-issues`는 vertical-slice issue draft 생성 surface입니다.
 - `/tk:browser-verify`는 번들된 browser-verify 엔진 skill을 현재 repo에 대응하는 `~/.tigerkit/repos/<repo-key>/browser-verify/` profile과 함께 사용하는 direct QA / behavior verification surface입니다.
@@ -60,6 +62,7 @@ TigerKit은 일반 autopilot 또는 sealed workflow engine이 아니라 gap, rou
 | `/tk:arch-review` | boundary, ownership, coupling, 반복 마찰을 evidence-first로 검토하는 report-only architecture review입니다. | inline architecture review |
 | `/tk:merge-conflict` | merge/rebase conflict를 상태 확인 → intent 추적 → 검증 순서로 해결합니다. | conflict resolution summary |
 | `/tk:handoff` | 다음 세션이나 다른 에이전트가 바로 이어받을 수 있는 handoff를 만듭니다. | worktree-scoped handoff artifact under repo-scoped `~/.tigerkit` root |
+| `/tk:handon` | 현재 repo/worktree의 최신 handoff draft를 다시 읽습니다. | read-only current handoff reopen under repo-scoped `~/.tigerkit` root |
 | `/tk:to-prd` | 현재 대화나 요구사항을 draft-only PRD로 정리합니다. | worktree-scoped PRD draft under repo-scoped `~/.tigerkit` root |
 | `/tk:to-issues` | plan/PRD를 independently grabbable vertical-slice issue draft로 분해합니다. | worktree-scoped issue draft set under repo-scoped `~/.tigerkit` root |
 | `/tk:browser-verify` | browser-verify 엔진 skill을 현재 repo에 대응하는 `~/.tigerkit/repos/<repo-key>/browser-verify/` profile과 함께 사용하는 direct QA / behavior verification surface입니다. | direct QA summary |
@@ -79,6 +82,7 @@ TigerKit은 일반 autopilot 또는 sealed workflow engine이 아니라 gap, rou
 /tk:arch-review "이 모듈 경계가 왜 자꾸 새는지 검토해줘"
 /tk:merge-conflict
 /tk:handoff "다음 세션용 handoff 만들어줘"
+/tk:handon "남은 작업만 짧게"
 /tk:to-prd "이 요구를 PRD로 정리해줘"
 /tk:to-issues "이 PRD를 issue draft로 쪼개줘"
 /tk:reflect --target skill --apply=true --desc "이 CDP 검증 루틴을 skill로 굳혀줘"
@@ -152,6 +156,12 @@ repo-local, repo-shared, user-global, skill, hook, command, agent, discard
 - 기본은 repo-scoped `~/.tigerkit` root 아래 worktree-scoped current-first write입니다.
 - Goal / Current state / Decisions / Changed files / Commands / Verification / Remaining tasks / Open questions / Risks / Suggested next skills / Do-not-repeat context를 포함합니다.
 
+## Handon model
+
+- 기본은 repo-scoped `~/.tigerkit` root 아래 worktree-scoped current-first read입니다.
+- source of truth는 `handoffs/current.md` 저장본입니다.
+- handoff가 없으면 missing path를 숨기지 않습니다.
+
 ## To-PRD model
 
 - 기본은 draft-only 입니다.
@@ -177,7 +187,7 @@ repo-local, repo-shared, user-global, skill, hook, command, agent, discard
 
 ## Generated state
 
-Active TigerKit runtime generated state는 project repository 밖 `~/.tigerkit` 아래의 file-only state입니다. repo-scoped draft artifact는 `~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/` 아래의 handoff / prd / issues current 경로를 사용하고, `/tk:browser-verify` profile은 `~/.tigerkit/repos/<repo-key>/browser-verify/`를 사용합니다.
+Active TigerKit runtime generated state는 project repository 밖 `~/.tigerkit` 아래의 file-only state입니다. repo-scoped draft artifact는 `~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/` 아래의 handoff / prd / issues current 경로를 사용하고, `/tk:handon`은 그 handoff current 경로를 읽습니다. `/tk:browser-verify` profile은 `~/.tigerkit/repos/<repo-key>/browser-verify/`를 사용합니다.
 
 주요 active path:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 TigerKit(`tk`, plugin namespace `/tk:*`)은 Claude Code용 경량 plugin입니다.
-SoT(Source of Truth)가 있으면 `/tk:gap`으로 현재 구현의 차이를 먼저 확인합니다. 다음 구현 route가 애매하면 `/tk:route`로 direct, subagent-driven, goal-driven 중 어떤 방식이 맞는지 얇게 정리합니다. 의미 있는 작업이 끝나면 `/tk:reflect`로 재사용 가능한 learning을 분류하고 repo-local/user-global guidance에 반영할 수 있습니다. path, URL, 현재 대화, notes, 또는 reflect candidate에서 skill을 바로 만들고 싶으면 `/tk:learn`을 씁니다. 또 구현 전 압박 검증은 `/tk:grill`(사용자가 답을 모른다고 **직접 말할 때만** 후보 최대 3개 제안 가능), guidance 감사/정비는 `/tk:grooming`, throwaway 검증은 `/tk:prototype`, 구조 리뷰는 `/tk:arch-review`, 충돌 해결은 `/tk:merge-conflict`, 세션 인계는 `/tk:handoff`, draft 요구 문서화는 `/tk:to-prd`, draft issue 분해는 `/tk:to-issues`로 다룹니다. browser-verify 엔진은 번들 skill로 유지하고, `/tk:browser-verify`는 현재 repo에 대응하는 `~/.tigerkit/repos/<repo-key>/browser-verify/` profile을 읽는 direct QA / behavior verification surface입니다.
+SoT(Source of Truth)가 있으면 `/tk:gap`으로 현재 구현의 차이를 먼저 확인합니다. 다음 구현 route가 애매하면 `/tk:route`로 direct, subagent-driven, goal-driven 중 어떤 방식이 맞는지 얇게 정리합니다. 의미 있는 작업이 끝나면 `/tk:reflect`로 재사용 가능한 learning을 분류하고 repo-local/user-global guidance에 반영할 수 있습니다. path, URL, 현재 대화, notes, 또는 reflect candidate에서 skill을 바로 만들고 싶으면 `/tk:learn`을 씁니다. 또 구현 전 압박 검증은 `/tk:grill`(사용자가 답을 모른다고 **직접 말할 때만** 후보 최대 3개 제안 가능), guidance 감사/정비는 `/tk:grooming`, throwaway 검증은 `/tk:prototype`, 구조 리뷰는 `/tk:arch-review`, 충돌 해결은 `/tk:merge-conflict`, 세션 인계는 `/tk:handoff`, 저장된 handoff 재호출은 `/tk:handon`, draft 요구 문서화는 `/tk:to-prd`, draft issue 분해는 `/tk:to-issues`로 다룹니다. browser-verify 엔진은 번들 skill로 유지하고, `/tk:browser-verify`는 현재 repo에 대응하는 `~/.tigerkit/repos/<repo-key>/browser-verify/` profile을 읽는 direct QA / behavior verification surface입니다.
 
 ```text
 Check the gap. Pick the route. Keep the learning. Materialize durable skills from reflect when needed.
@@ -26,7 +26,7 @@ Check the gap. Pick the route. Keep the learning. Materialize durable skills fro
 이후에는 필요할 때만 나머지 surface를 꺼내 쓰면 됩니다.
 
 - Practical: `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:browser-verify`, `/tk:arch-review`, `/tk:merge-conflict`
-- Output: `/tk:handoff`, `/tk:to-prd`, `/tk:to-issues`
+- Output: `/tk:handoff`, `/tk:handon`, `/tk:to-prd`, `/tk:to-issues`
 
 ## Installation
 
@@ -44,7 +44,7 @@ claude plugin list --available --json
 claude plugin details tk
 ```
 
-설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:browser-verify`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:to-prd`, `/tk:to-issues` 명령을 사용합니다.
+설치 후 Claude Code를 다시 시작하고 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:browser-verify`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:handon`, `/tk:to-prd`, `/tk:to-issues` 명령을 사용합니다.
 
 ## Core guidance
 
@@ -60,6 +60,7 @@ claude plugin details tk
 - `/tk:arch-review`는 반복 마찰, 경계 붕괴, ownership 혼선 같은 구조 문제를 report-only로 검토합니다.
 - `/tk:merge-conflict`는 merge/rebase conflict를 ours/theirs intent 기준으로 해결합니다.
 - `/tk:handoff`는 다음 세션이나 다른 에이전트가 바로 이어받을 수 있는 handoff를 만듭니다.
+- `/tk:handon`은 현재 repo/worktree의 저장된 handoff를 다시 읽습니다.
 - `/tk:to-prd`는 현재 대화나 요구사항을 draft-only PRD로 정리합니다.
 - `/tk:to-issues`는 plan/PRD를 vertical-slice issue draft로 분해합니다.
 - `/tk:browser-verify`는 번들된 browser-verify 엔진 skill을 현재 repo에 대응하는 `~/.tigerkit/repos/<repo-key>/browser-verify/` profile과 함께 사용하는 direct QA / behavior verification surface입니다.
@@ -91,6 +92,7 @@ claude plugin details tk
 | Command | 역할 | 저장 성격 |
 | --- | --- | --- |
 | `/tk:handoff` | 다음 세션이나 다른 에이전트가 바로 이어받을 수 있는 handoff를 만듭니다. | worktree-scoped handoff artifact under repo-scoped `~/.tigerkit` root |
+| `/tk:handon` | 현재 repo/worktree의 최신 handoff draft를 다시 읽습니다. | read-only current handoff reopen under repo-scoped `~/.tigerkit` root |
 | `/tk:to-prd` | 현재 대화나 요구사항을 draft-only PRD로 정리합니다. | worktree-scoped PRD draft under repo-scoped `~/.tigerkit` root |
 | `/tk:to-issues` | plan/PRD를 independently grabbable vertical-slice issue draft로 분해합니다. | worktree-scoped issue draft set under repo-scoped `~/.tigerkit` root |
 
@@ -109,6 +111,7 @@ claude plugin details tk
 /tk:arch-review "이 모듈 경계가 왜 자꾸 새는지 검토해줘"
 /tk:merge-conflict
 /tk:handoff "issue 138 skill-first rollout 상태 넘겨줘"
+/tk:handon "남은 작업만 짧게"
 /tk:to-prd "이 요구를 PRD draft로 정리해줘"
 /tk:to-issues "이 PRD를 issue draft로 쪼개줘"
 /tk:reflect --target skill --apply=true --desc "이 CDP 검증 루틴을 skill로 굳혀줘"
@@ -188,6 +191,8 @@ Active generated state는 project repository 밖 `~/.tigerkit/` 아래의 file-o
   - `~/.tigerkit/repos/<repo-key>/branches/<scope-key>/reflect/current.yaml`
 - `/tk:handoff` draft:
   - `~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/handoffs/current.md`
+- `/tk:handon` read target:
+  - `~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/handoffs/current.md`
 - `/tk:to-prd` draft:
   - `~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/prd/current.md`
 - `/tk:to-issues` draft:
@@ -200,7 +205,7 @@ Active generated state는 project repository 밖 `~/.tigerkit/` 아래의 file-o
 - `/tk:route`는 기본적으로 persisted artifact를 만들지 않습니다.
 - `/tk:browser-verify`는 repo-scoped profile을 `~/.tigerkit` 아래에서 읽고, legacy profile이 있으면 migration guide를 출력하며, 둘 다 없을 때만 missing 파일을 bootstrap할 수 있습니다.
 
-`/tk:handoff`, `/tk:to-prd`, `/tk:to-issues`의 canonical draft artifact는 repo 내부 `.claude/tigerkit/`가 아니라 `~/.tigerkit` 아래 worktree-scoped current-first 구조로 기록됩니다. `.claude/` 전체를 ignore하지 않습니다.
+`/tk:handoff`, `/tk:handon`, `/tk:to-prd`, `/tk:to-issues`는 repo 내부 `.claude/tigerkit/`가 아니라 `~/.tigerkit` 아래 worktree-scoped current-first draft 구조를 사용합니다. `/tk:handoff`는 그 경로에 기록하고, `/tk:handon`은 같은 current handoff를 다시 읽습니다. `.claude/` 전체를 ignore하지 않습니다.
 
 ## Contributors
 

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -46,6 +46,8 @@ skills/handoff/SKILL.md
 
 `repo-key`와 `worktree-key`는 `scripts/tigerkit_state.py` helper가 계산합니다.
 
+같은 current handoff를 다시 읽으려면 `/tk:handon`을 사용합니다.
+
 ## Output contract
 
 - section label은 항상 `🎯 Goal:`처럼 leading emoji를 붙인 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.

--- a/commands/handon.md
+++ b/commands/handon.md
@@ -1,0 +1,82 @@
+---
+description: 현재 worktree의 최신 handoff draft를 다시 읽습니다.
+argument-hint: '["<focus or question>"] [--path-only]'
+---
+
+이 문서는 TigerKit `/tk:handon` command contract를 정의합니다.
+
+사용자에게는 한글로 답합니다. 코드, path, URL, identifier, command, YAML/JSON field name은 원문 그대로 둘 수 있습니다.
+
+목표: `/tk:handon`은 `/tk:handoff`가 남긴 current-first handoff artifact를 현재 repo/worktree 기준으로 다시 여는 read-only surface입니다. 저장된 handoff 파일을 source of truth로 읽고, 필요하면 focus에 맞춰 짧게 요약하거나 경로만 확인해줍니다.
+
+canonical skill:
+
+```text
+skills/handon/SKILL.md
+```
+
+```text
+handon = current repo/worktree handoff current.md -> read saved artifact -> resume work
+```
+
+## Core boundary
+
+- read-only 입니다.
+- 기본은 현재 repo/worktree의 `handoffs/current.md`만 읽습니다.
+- source of truth는 저장된 handoff artifact이며, chat memory나 추측으로 빈칸을 메우지 않습니다.
+- handoff가 없으면 missing path를 숨기지 않고 그대로 보여줍니다.
+- 기존 handoff를 regenerate, overwrite, append 하지 않습니다.
+
+## Default source path
+
+```text
+~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/handoffs/current.md
+```
+
+`repo-key`와 `worktree-key`는 `scripts/tigerkit_state.py draft-paths --kind handoffs` helper가 계산합니다.
+
+helper 예시:
+
+```bash
+python3 "$TIGERKIT_STATE_SCRIPT" draft-paths --repo-root "$PWD" --kind handoffs
+```
+
+## Output contract
+
+- section label은 항상 `🎯 Goal:`처럼 leading emoji를 붙인 `라벨:` 한 줄 뒤 바로 다음 줄에 내용을 둡니다. 라벨 뒤 빈 줄을 두지 않습니다.
+- 같은 역할의 label은 가능하면 같은 emoji를 재사용합니다.
+- top-level section label에만 emoji를 붙이고, nested bullet label은 plain을 우선합니다.
+- compact는 유지하되 section 사이에는 한 줄 여백을 두어 읽힘을 확보합니다.
+- 긴 설명은 가능하면 bullet을 쪼개서 한 줄에 한 뜻만 남깁니다.
+- optional section은 비어 있으면 통째로 생략합니다. 의미 보존이 필요한 receipt가 아니면 `NONE`을 출력하지 않습니다.
+
+```text
+Handon 읽기 완료 | Handon 경로 확인 | Handon 없음
+📁 Handoff path:
+- <path>
+[📝 Focus:
+- <focus or question>]
+📝 Source:
+- current repo/worktree handoff artifact
+[📝 Summary:
+- <compact summary from saved handoff>]
+[⚠️ Missing:
+- no current handoff draft found]
+▶️ Next step:
+- <resume from remaining tasks | create a new handoff with /tk:handoff>
+```
+
+## Examples
+
+```text
+/tk:handon
+/tk:handon "남은 작업만 짧게"
+/tk:handon --path-only
+```
+
+## Non-goals
+
+- 새 handoff 생성
+- 기존 handoff 수정
+- current handoff가 없을 때 예전 draft를 임의 선택
+- chat log를 source of truth로 대체

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -21,7 +21,7 @@ reflect = session result + feedback -> classify learning -> default repo-local/u
 
 ## Core boundary
 
-- Active command surface는 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:to-prd`, `/tk:to-issues`, `/tk:browser-verify`입니다.
+- Active command surface는 `/tk:gap`, `/tk:route`, `/tk:reflect`, `/tk:learn`, `/tk:grill`, `/tk:grooming`, `/tk:prototype`, `/tk:arch-review`, `/tk:merge-conflict`, `/tk:handoff`, `/tk:handon`, `/tk:to-prd`, `/tk:to-issues`, `/tk:browser-verify`입니다.
 - `/tk:reflect`는 Claude Code auto memory를 쓰거나, mirror하거나, backup하지 않습니다.
 - `/tk:reflect`는 source code, repo-shared guidance, hook settings, command source, agent source, plugin manifest를 수정하지 않습니다.
 - `skill` source materialization은 `--target skill --apply=true`일 때만 허용되며, skill authoring은 `/tk:learn` pipeline으로 위임합니다.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -1,7 +1,7 @@
 {
-  "skill_name": "tiger-kit-gap-route-reflect-learn-browser-verify-grill-grooming-prototype-arch-review-merge-conflict-handoff-to-prd-to-issues-core",
+  "skill_name": "tiger-kit-gap-route-reflect-learn-browser-verify-grill-grooming-prototype-arch-review-merge-conflict-handoff-handon-to-prd-to-issues-core",
   "command_surface": {
-    "surface_model": "TigerKit exposes Claude Code plugin commands only; commands/*.md and .claude-plugin/plugin.json own /tk:* contracts. Active command surface is /tk:gap, /tk:route, /tk:reflect, /tk:learn, /tk:browser-verify, /tk:grill, /tk:grooming, /tk:prototype, /tk:arch-review, /tk:merge-conflict, /tk:handoff, /tk:to-prd, and /tk:to-issues.",
+    "surface_model": "TigerKit exposes Claude Code plugin commands only; commands/*.md and .claude-plugin/plugin.json own /tk:* contracts. Active command surface is /tk:gap, /tk:route, /tk:reflect, /tk:learn, /tk:browser-verify, /tk:grill, /tk:grooming, /tk:prototype, /tk:arch-review, /tk:merge-conflict, /tk:handoff, /tk:handon, /tk:to-prd, and /tk:to-issues.",
     "core_commands": [
       "/tk:gap",
       "/tk:route",
@@ -14,6 +14,7 @@
       "/tk:arch-review",
       "/tk:merge-conflict",
       "/tk:handoff",
+      "/tk:handon",
       "/tk:to-prd",
       "/tk:to-issues"
     ],
@@ -32,11 +33,12 @@
       "id": 0,
       "name": "plugin-version-and-command-manifest-gap-route-reflect-browser-verify-plus-phase1-and-conditional",
       "prompt": "Evaluate TigerKit active command surface and plugin packaging. Do not write files.",
-      "expected_output": "Should list /tk:gap, /tk:route, /tk:reflect, /tk:learn, /tk:browser-verify, /tk:grill, /tk:grooming, /tk:prototype, /tk:arch-review, /tk:merge-conflict, /tk:handoff, /tk:to-prd, and /tk:to-issues as the active commands. Should state /tk:learn is a source-to-skill surface with preview-default and skill-only write boundary. Should state /tk:route is a decision/brainstorming surface, not a runner or autopilot. Should state /tk:reflect is the durable promotion router with repo-local/user-global default apply and explicit skill materialize mode, /tk:grill is a questioning surface, /tk:grooming is a report-first guidance audit surface with user-global-only direct apply, /tk:prototype is a throwaway validation surface, /tk:arch-review is a report-only architecture review surface, /tk:merge-conflict is a conflict-resolution surface, /tk:handoff is a worktree-scoped current-first handoff surface under repo-scoped ~/.tigerkit, /tk:to-prd is a worktree-scoped current-first draft-only PRD surface under repo-scoped ~/.tigerkit, /tk:to-issues is a worktree-scoped current-first vertical-slice issue draft surface under repo-scoped ~/.tigerkit, and /tk:browser-verify is a direct QA / behavior verification surface.",
+      "expected_output": "Should list /tk:gap, /tk:route, /tk:reflect, /tk:learn, /tk:browser-verify, /tk:grill, /tk:grooming, /tk:prototype, /tk:arch-review, /tk:merge-conflict, /tk:handoff, /tk:handon, /tk:to-prd, and /tk:to-issues as the active commands. Should state /tk:learn is a source-to-skill surface with preview-default and skill-only write boundary. Should state /tk:route is a decision/brainstorming surface, not a runner or autopilot. Should state /tk:reflect is the durable promotion router with repo-local/user-global default apply and explicit skill materialize mode, /tk:grill is a questioning surface, /tk:grooming is a report-first guidance audit surface with user-global-only direct apply, /tk:prototype is a throwaway validation surface, /tk:arch-review is a report-only architecture review surface, /tk:merge-conflict is a conflict-resolution surface, /tk:handoff is a worktree-scoped current-first handoff surface under repo-scoped ~/.tigerkit, /tk:handon is a read-only current-first handoff reopen surface under repo-scoped ~/.tigerkit, /tk:to-prd is a worktree-scoped current-first draft-only PRD surface under repo-scoped ~/.tigerkit, /tk:to-issues is a worktree-scoped current-first vertical-slice issue draft surface under repo-scoped ~/.tigerkit, and /tk:browser-verify is a direct QA / behavior verification surface.",
       "files": [
         ".claude-plugin/plugin.json",
         "README.md",
         ".tigerkit/docs/usage.md",
+        "commands/handon.md",
         "commands/route.md",
         "commands/reflect.md"
       ],
@@ -52,6 +54,7 @@
         "Lists /tk:arch-review",
         "Lists /tk:merge-conflict",
         "Lists /tk:handoff",
+        "Lists /tk:handon",
         "Lists /tk:to-prd",
         "Lists /tk:to-issues",
         "States /tk:route is decision/brainstorming only",
@@ -63,6 +66,7 @@
         "States /tk:arch-review is report-only architecture review surface",
         "States /tk:merge-conflict is conflict-resolution surface",
         "States /tk:handoff is worktree-scoped current-first handoff surface under repo-scoped ~/.tigerkit",
+        "States /tk:handon is read-only current-first handoff reopen surface under repo-scoped ~/.tigerkit",
         "States /tk:to-prd is worktree-scoped current-first draft-only PRD surface under repo-scoped ~/.tigerkit",
         "States /tk:to-issues is worktree-scoped current-first vertical-slice issue draft surface under repo-scoped ~/.tigerkit",
         "States /tk:browser-verify is direct QA / behavior verification surface",
@@ -680,6 +684,27 @@
         "Warns draft must not jump straight to shipped",
         "States FULL pilot does not automatically mean shipped",
         "Includes at least one command surface example in the sample registry"
+      ]
+    },
+    {
+      "id": 37,
+      "name": "handon-reads-current-worktree-handoff-artifact",
+      "prompt": "Evaluate /tk:handon behavior. Do not write files.",
+      "expected_output": "Should treat /tk:handon as a read-only current-first handoff reopen surface for the current repo/worktree. It should resolve `~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/handoffs/current.md`, read that saved artifact as the source of truth when present, support path-only or focused re-read styles, avoid regenerating or overwriting the handoff, and report the missing path honestly when no current handoff exists.",
+      "files": [
+        "commands/handon.md",
+        "skills/handon/SKILL.md",
+        "README.md",
+        ".tigerkit/docs/usage.md",
+        ".tigerkit/docs/output-contract.md"
+      ],
+      "expectations": [
+        "Defines /tk:handon as read-only",
+        "Uses current repo worktree handoff path under ~/.tigerkit",
+        "Reads handoffs/current.md as source of truth",
+        "Does not regenerate overwrite or append the handoff",
+        "Supports focused re-read or path-only style",
+        "Reports missing path honestly when current handoff is absent"
       ]
     }
   ]

--- a/scripts/check-command-surface-drift.py
+++ b/scripts/check-command-surface-drift.py
@@ -27,6 +27,7 @@ EXPECTED_ACTIVE_COMMANDS = {
     "./commands/arch-review.md",
     "./commands/merge-conflict.md",
     "./commands/handoff.md",
+    "./commands/handon.md",
     "./commands/to-prd.md",
     "./commands/to-issues.md",
 }
@@ -43,6 +44,7 @@ README_COMMANDS = {
     "/tk:arch-review",
     "/tk:merge-conflict",
     "/tk:handoff",
+    "/tk:handon",
     "/tk:to-prd",
     "/tk:to-issues",
 }
@@ -74,6 +76,7 @@ COMMAND_OUTPUT_PATHS = {
     "arch-review": ROOT / "commands" / "arch-review.md",
     "merge-conflict": ROOT / "commands" / "merge-conflict.md",
     "handoff": ROOT / "commands" / "handoff.md",
+    "handon": ROOT / "commands" / "handon.md",
     "to-prd": ROOT / "commands" / "to-prd.md",
     "to-issues": ROOT / "commands" / "to-issues.md",
 }
@@ -90,6 +93,7 @@ OUTPUT_SYNC_TARGETS = {
     "arch-review": "## `/tk:arch-review` Output Contract",
     "merge-conflict": "## `/tk:merge-conflict` Output Contract",
     "handoff": "## `/tk:handoff` Output Contract",
+    "handon": "## `/tk:handon` Output Contract",
     "to-prd": "## `/tk:to-prd` Output Contract",
     "to-issues": "## `/tk:to-issues` Output Contract",
 }
@@ -104,6 +108,7 @@ TEXT_OUTPUT_COMMANDS_NO_NONE = {
     "arch-review",
     "merge-conflict",
     "handoff",
+    "handon",
     "to-prd",
     "to-issues",
     "browser-verify",

--- a/scripts/check-plugin-version.py
+++ b/scripts/check-plugin-version.py
@@ -75,6 +75,7 @@ def main() -> int:
         "./commands/arch-review.md",
         "./commands/merge-conflict.md",
         "./commands/handoff.md",
+        "./commands/handon.md",
         "./commands/to-prd.md",
         "./commands/to-issues.md",
     }

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -47,6 +47,8 @@ description: 다음 세션이나 다른 에이전트가 바로 이어받을 수 
 
 `repo-key`와 `worktree-key`는 `scripts/tigerkit_state.py` helper가 계산합니다.
 
+같은 current handoff를 다시 열 때는 `/tk:handon`을 사용합니다.
+
 ## Boundaries
 
 - repo-scoped `~/.tigerkit` root 아래 worktree-scoped current-first write 기본

--- a/skills/handon/SKILL.md
+++ b/skills/handon/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: handon
+description: 현재 repo/worktree의 최신 handoff draft를 다시 읽습니다.
+---
+
+# Handon
+
+`/tk:handoff`가 남긴 current-first handoff artifact를 다시 열어 다음 작업을 바로 이어가기 위한 read-only skill입니다.
+
+## Goal
+
+- 현재 repo/worktree의 최신 handoff를 source of truth로 읽습니다.
+- handoff가 있으면 남은 작업과 리스크를 빠르게 복구합니다.
+- handoff가 없으면 expected path를 정확히 알려주고 추측하지 않습니다.
+
+## Default source path
+
+```text
+~/.tigerkit/repos/<repo-key>/worktrees/<worktree-key>/handoffs/current.md
+```
+
+`repo-key`와 `worktree-key`는 `scripts/tigerkit_state.py draft-paths --kind handoffs` helper가 계산합니다.
+
+## Process
+
+1. 현재 repo/worktree 기준 handoff 경로를 계산합니다.
+2. `current.md`가 있으면 그 파일을 source of truth로 읽습니다.
+3. 사용자가 focus를 줬으면 그 범위만 더 짧게 정리합니다.
+4. handoff가 없으면 missing path를 숨기지 않고 그대로 말합니다.
+5. 필요한 첫 행동을 한 줄로 남깁니다.
+
+## Boundaries
+
+- read-only 입니다.
+- handoff를 regenerate, overwrite, append 하지 않습니다.
+- chat memory나 추측으로 빠진 section을 보완하지 않습니다.
+- 기본은 current repo/worktree handoff 하나만 읽습니다.
+
+## Good use cases
+
+- `/clear` 뒤 직전 handoff 다시 열기
+- 다른 agent가 남긴 current handoff 빠르게 복구하기
+- 남은 작업 / 리스크 / next step만 짧게 다시 보기
+- handoff 파일 path만 확인하기


### PR DESCRIPTION
## 요약
- `/tk:handon` command와 `skills/handon`을 추가해 current handoff 재호출 surface를 제공합니다
- plugin manifest, README, usage/output contract, evals, validation scripts를 `/tk:handon` 표면에 맞춰 정렬합니다
- plugin version을 `16.5.13`로 patch bump 합니다

## 검증
- [x] `python3 scripts/check-plugin-version.py`
- [x] `yarn validate`

Closes #163