### PR TITLE
test: support linked worktree validation and release 16.5.17

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tk",
   "description": "TigerKit `/tk:*` command plugin입니다.",
-  "version": "16.5.16",
+  "version": "16.5.17",
   "author": {
     "name": "MTGVim"
   },

--- a/scripts/test-check-micro-eval-pilots.py
+++ b/scripts/test-check-micro-eval-pilots.py
@@ -150,7 +150,11 @@ def recorded_commit_blob_mismatch(result: dict[str, Any], checkout: Path) -> Non
 
 
 def no_git_archive(_result: dict[str, Any], checkout: Path) -> None:
-    shutil.rmtree(checkout / ".git")
+    git_metadata = checkout / ".git"
+    if git_metadata.is_dir():
+        shutil.rmtree(git_metadata)
+    else:
+        git_metadata.unlink()
 
 
 def source_path_traversal(result: dict[str, Any], _checkout: Path) -> None:


### PR DESCRIPTION
## 요약
- linked worktree에서 `.git`이 파일인 경우에도 MICRO validator adversarial test가 동작하도록 수정
- TigerKit plugin version을 `16.5.17`로 patch bump

## 문제
- `no_git_archive` fixture가 `.git`을 항상 디렉터리로 가정해 linked worktree에서 `NotADirectoryError`로 실패했습니다.

## 수정
- `.git`이 디렉터리면 `shutil.rmtree()`, 파일이면 `Path.unlink()`를 사용합니다.
- `.claude-plugin/plugin.json` version을 `16.5.17`로 갱신했습니다.

## 검증
- [x] targeted MICRO validator adversarial test
- [x] `yarn test`
- [x] `yarn validate`
- [x] independent review PASS
