### PR TITLE
feat: label skill invocation modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 18.0.2 — Invocation Labels
+
+- Prefixed skill descriptions with `[user]`, `[auto]`, or `[user/auto]` so picker entries communicate their intended invocation.
+- Mirrored `[user]` in Codex interface descriptions for explicitly invoked skills.
+- Enforced invocation labels in repository validation without renaming skills or changing invocation kinds.
+
 ## 18.0.1 — README Invocation Guide
 
 - Distinguished user-invoked, model-invoked, and hybrid skills throughout the README catalog.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ npx skills add MTGVim/tiger-kit \
   --skill tk-browser-verify
 ```
 
-Install the immutable 18.0.1 snapshot:
+Install the immutable 18.0.2 snapshot:
 
 ```bash
-npx skills add "MTGVim/tiger-kit#v18.0.1" \
+npx skills add "MTGVim/tiger-kit#v18.0.2" \
   --global \
   --agent claude-code \
   --agent codex \
@@ -45,9 +45,9 @@ Claude Code and Hermes Agent expose installed skills as slash commands such as `
 
 ## Skill catalog
 
-- **User-invoked**: the user explicitly selects the skill, such as `/tk-implement` or `$tk-implement`.
-- **Model-invoked**: the model routes to the skill when its discipline is relevant.
-- **Hybrid**: either explicit user selection or model routing is supported.
+- **`[user]` User-invoked**: the user explicitly selects the skill, such as `/tk-implement` or `$tk-implement`.
+- **`[auto]` Model-invoked**: the model routes to the skill when its discipline is relevant.
+- **`[user/auto]` Hybrid**: either explicit user selection or model routing is supported.
 
 ### Shape
 

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -9,6 +9,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS = ROOT / "skills"
 KINDS = {"user-invoked", "model-invoked", "hybrid"}
+INVOCATION_LABELS = {
+    "user-invoked": "[user]",
+    "model-invoked": "[auto]",
+    "hybrid": "[user/auto]",
+}
 RELATIONSHIPS = {"copied", "adapted", "inspired-by", "forked", "native"}
 EXPECTED_SKILLS = {
     "tk-grill-me", "tk-grill-with-docs", "tk-grilling", "tk-domain-modeling",
@@ -102,8 +107,12 @@ def validate_skill(path: Path) -> tuple[list[str], list[str]]:
         errors.append(f"{label}: SKILL.md field name: use tk- prefixed kebab-case")
     if not isinstance(description, str) or not description.strip():
         errors.append(f"{label}: SKILL.md field description: add a non-empty description")
-    if kind not in KINDS:
+    if not isinstance(kind, str) or kind not in KINDS:
         errors.append(f"{label}: metadata.tigerkit.kind: use one of {sorted(KINDS)}")
+    elif isinstance(description, str) and not description.startswith(f"{INVOCATION_LABELS[kind]} "):
+        errors.append(
+            f"{label}: SKILL.md field description: prefix with {INVOCATION_LABELS[kind]!r}"
+        )
     if relationship not in RELATIONSHIPS:
         errors.append(f"{label}: metadata.tigerkit.relationship: use one of {sorted(RELATIONSHIPS)}")
     if origin != "tigerkit" and not nested(data, "metadata", "tigerkit", "upstream-skill"):
@@ -125,6 +134,8 @@ def validate_skill(path: Path) -> tuple[list[str], list[str]]:
             for needle in ("interface:", "display_name:", "short_description:", "policy:", "allow_implicit_invocation: false"):
                 if needle not in openai_text:
                     errors.append(f"{label}: agents/openai.yaml: add {needle}")
+            if 'short_description: "[user] ' not in openai_text:
+                errors.append(f"{label}: agents/openai.yaml: prefix short_description with '[user]'")
     elif kind in {"model-invoked", "hybrid"}:
         if disabled:
             errors.append(f"{label}: disable-model-invocation: remove implicit-invocation block")

--- a/skills/tk-browser-verify/SKILL.md
+++ b/skills/tk-browser-verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-browser-verify
-description: "Verify browser UI, behavior, environment differences, and design fidelity with runtime evidence."
+description: "[user/auto] Verify browser UI, behavior, environment differences, and design fidelity with runtime evidence."
 metadata:
   tigerkit:
     kind: hybrid

--- a/skills/tk-code-review/SKILL.md
+++ b/skills/tk-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-code-review
-description: "Review a fixed diff for specification compliance and code quality without editing it."
+description: "[auto] Review a fixed diff for specification compliance and code quality without editing it."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-codebase-design/SKILL.md
+++ b/skills/tk-codebase-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-codebase-design
-description: "Identify evidence-backed structural pain and propose the smallest effective codebase design improvement."
+description: "[auto] Identify evidence-backed structural pain and propose the smallest effective codebase design improvement."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-diagnosing-bugs/SKILL.md
+++ b/skills/tk-diagnosing-bugs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-diagnosing-bugs
-description: "Diagnose difficult bugs by reproducing, minimizing, testing hypotheses, and verifying a regression fix."
+description: "[auto] Diagnose difficult bugs by reproducing, minimizing, testing hypotheses, and verifying a regression fix."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-domain-modeling/SKILL.md
+++ b/skills/tk-domain-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-domain-modeling
-description: "Sharpen domain language, test concept boundaries, and record only durable terms or consequential decisions."
+description: "[auto] Sharpen domain language, test concept boundaries, and record only durable terms or consequential decisions."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-grill-me/SKILL.md
+++ b/skills/tk-grill-me/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-grill-me
-description: "Pressure-test an idea, plan, design, ticket, or RFC. Use only when explicitly invoked by the user."
+description: "[user] Pressure-test an idea, plan, design, ticket, or RFC. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<idea, plan, design, ticket, RFC, or path>"
 metadata:

--- a/skills/tk-grill-me/agents/openai.yaml
+++ b/skills/tk-grill-me/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Grill Me"
-  short_description: "Pressure-test a plan one decision at a time."
+  short_description: "[user] Pressure-test a plan one decision at a time."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-grill-with-docs/SKILL.md
+++ b/skills/tk-grill-with-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-grill-with-docs
-description: "Pressure-test decisions and record settled domain terms or consequential ADRs. Use only when explicitly invoked by the user."
+description: "[user] Pressure-test decisions and record settled domain terms or consequential ADRs. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<idea, plan, design, ticket, RFC, or path>"
 metadata:

--- a/skills/tk-grill-with-docs/agents/openai.yaml
+++ b/skills/tk-grill-with-docs/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Grill With Docs"
-  short_description: "Converge decisions and record durable context."
+  short_description: "[user] Converge decisions and record durable context."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-grilling/SKILL.md
+++ b/skills/tk-grilling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-grilling
-description: "Ask one consequential design question at a time with a recommendation and evidence."
+description: "[auto] Ask one consequential design question at a time with a recommendation and evidence."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-grooming/SKILL.md
+++ b/skills/tk-grooming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-grooming
-description: "Audit and optionally repair existing repo and user rules or skills. Use only when explicitly invoked by the user."
+description: "[user] Audit and optionally repair existing repo and user rules or skills. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "[scope] [--apply]"
 metadata:

--- a/skills/tk-grooming/agents/openai.yaml
+++ b/skills/tk-grooming/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Grooming"
-  short_description: "Audit and optionally repair rules and skills."
+  short_description: "[user] Audit and optionally repair rules and skills."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-handoff/SKILL.md
+++ b/skills/tk-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-handoff
-description: "Write or resume a verified work handoff. Use only when explicitly invoked by the user."
+description: "[user] Write or resume a verified work handoff. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "[goal or audience] [--output <path>|--resume]"
 metadata:

--- a/skills/tk-handoff/agents/openai.yaml
+++ b/skills/tk-handoff/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Handoff"
-  short_description: "Write or resume a verified work handoff."
+  short_description: "[user] Write or resume a verified work handoff."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-implement/SKILL.md
+++ b/skills/tk-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-implement
-description: "Implement and verify a requested code change. Use only when explicitly invoked by the user."
+description: "[user] Implement and verify a requested code change. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<request, ticket, or spec>"
 metadata:

--- a/skills/tk-implement/agents/openai.yaml
+++ b/skills/tk-implement/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Implement"
-  short_description: "Implement and verify a requested code change."
+  short_description: "[user] Implement and verify a requested code change."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-learn/SKILL.md
+++ b/skills/tk-learn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-learn
-description: "Create a reusable repo or user skill from supplied experience or material. Use only when explicitly invoked by the user."
+description: "[user] Create a reusable repo or user skill from supplied experience or material. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<conversation, notes, path, URL, workflow, or reflect candidate>"
 metadata:

--- a/skills/tk-learn/agents/openai.yaml
+++ b/skills/tk-learn/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Learn"
-  short_description: "Turn evidence into a reusable repo or user skill."
+  short_description: "[user] Turn evidence into a reusable repo or user skill."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-merge-conflict/SKILL.md
+++ b/skills/tk-merge-conflict/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-merge-conflict
-description: "Resolve active merge or rebase conflicts while preserving both sides intent and verifying the result."
+description: "[auto] Resolve active merge or rebase conflicts while preserving both sides intent and verifying the result."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-prototype/SKILL.md
+++ b/skills/tk-prototype/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-prototype
-description: "Build a throwaway UI or logic prototype to test a hypothesis. Use only when explicitly invoked by the user."
+description: "[user] Build a throwaway UI or logic prototype to test a hypothesis. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<idea, screenshot, spec, ticket, code, or design reference>"
 metadata:

--- a/skills/tk-prototype/agents/openai.yaml
+++ b/skills/tk-prototype/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Prototype"
-  short_description: "Build a throwaway UI or logic prototype."
+  short_description: "[user] Build a throwaway UI or logic prototype."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-reflect/SKILL.md
+++ b/skills/tk-reflect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-reflect
-description: "Extract reusable rule or skill candidates from evidence. Use only when explicitly invoked by the user."
+description: "[user] Extract reusable rule or skill candidates from evidence. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<conversation, correction, diff, result, or source>"
 metadata:

--- a/skills/tk-reflect/agents/openai.yaml
+++ b/skills/tk-reflect/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: Reflect"
-  short_description: "Propose durable rule or skill candidates from evidence."
+  short_description: "[user] Propose durable rule or skill candidates from evidence."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-tdd/SKILL.md
+++ b/skills/tk-tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-tdd
-description: "Use test-driven development at a valuable behavior seam when red-green-refactor improves confidence."
+description: "[auto] Use test-driven development at a valuable behavior seam when red-green-refactor improves confidence."
 user-invocable: false
 metadata:
   tigerkit:

--- a/skills/tk-to-spec/SKILL.md
+++ b/skills/tk-to-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-to-spec
-description: "Synthesize current decisions and evidence into an implementation specification. Use only when explicitly invoked by the user."
+description: "[user] Synthesize current decisions and evidence into an implementation specification. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<conversation, source, or request> [--output <path>|--print-only]"
 metadata:

--- a/skills/tk-to-spec/agents/openai.yaml
+++ b/skills/tk-to-spec/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: To Spec"
-  short_description: "Synthesize evidence into an implementation spec."
+  short_description: "[user] Synthesize evidence into an implementation spec."
 
 policy:
   allow_implicit_invocation: false

--- a/skills/tk-to-tickets/SKILL.md
+++ b/skills/tk-to-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-to-tickets
-description: "Split a request or specification into independently verifiable vertical tickets. Use only when explicitly invoked by the user."
+description: "[user] Split a request or specification into independently verifiable vertical tickets. Use only when explicitly invoked by the user."
 disable-model-invocation: true
 argument-hint: "<spec, plan, or request> [--output <path>]"
 metadata:

--- a/skills/tk-to-tickets/agents/openai.yaml
+++ b/skills/tk-to-tickets/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "TigerKit: To Tickets"
-  short_description: "Create independently verifiable vertical tickets."
+  short_description: "[user] Create independently verifiable vertical tickets."
 
 policy:
   allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- label all skill descriptions as `[user]`, `[auto]`, or `[user/auto]`
- mirror `[user]` into Codex interface descriptions
- enforce description labels from `metadata.tigerkit.kind`
- prepare the `18.0.2` changelog and stable install example

## Verification

- `python3 scripts/validate_skills.py`
- `python3 scripts/validate_skills.py --links-only`
- `npx --yes skills add . --list`
- `git diff --check`
- verified label counts: 10 `[user]`, 7 `[auto]`, 1 `[user/auto]`
- temporary-home smoke install copied all 18 skills and representative references to Claude Code, Codex, and Hermes Agent
