### PR TITLE
Release v20.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 20.1.6 — Structured User Decision Questions
+
+- Standardized a self-contained user-decision question contract across all 13
+  canonical skills, with one question at a time, two or three mutually
+  exclusive proposals, material tradeoffs, and exactly one localized
+  recommendation marker.
+- Required `Question` to precede `Recommendation` and to explain the
+  evidence-derived context, decision impact, and unresolved axis in readable
+  user-facing prose instead of requiring users to decode raw evidence.
+- Required native structured user-input tools whenever the active host exposes
+  one, with explicit Claude Code `AskUserQuestion`, Codex
+  `request_user_input`, and Hermes Agent `clarify` examples and prose fallback
+  only when no such tool is available.
+- Made supported option previews and prototype cards proactive aids when they
+  clarify a decision without expanding the owning skill's authority.
+- Added repository validation, unit coverage, and the required
+  `grill-uses-native-question-tool` behavior-eval contract to prevent drift in
+  ordering, readability, tool gating, option count, and recommendation
+  labeling.
+
 ## 20.1.5 — Empirical Agent Skill Diagnosis and Catalog Reliability
 
 - Expanded the catalog from 12 to 13 canonical skills while retaining one

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,25 @@
+# TigerKit 20.1.6 structured user decision questions
+
+TigerKit 20.1.6 preserves all 13 canonical skills and their invocation
+boundaries. Every skill now uses the same presentation contract when it owns a
+user decision: one question at a time, two or three mutually exclusive
+proposals, and exactly one localized recommendation marker.
+
+The `Question` field now appears before `Recommendation` and explains the
+evidence-derived context, decision impact, and unresolved axis in readable
+user-facing prose. Raw `Evidence` remains available for traceability but is no
+longer required reading to understand the choice.
+
+When the active host exposes a native structured user-input tool, the skill
+must use it. The canonical examples are Claude Code `AskUserQuestion`, Codex
+`request_user_input`, and Hermes Agent `clarify`. Plain-text fallback is
+allowed only when no equivalent tool is exposed. Supported option previews or
+prototype cards should be used when they materially clarify the choice.
+
+No skill name, phase ownership rule, explicit invocation path, runtime surface,
+or installation command changes in this release. Consumers only need to
+refresh the installed skill package.
+
 # TigerKit 20.1.5 empirical diagnosis and catalog refinement
 
 This release expands the catalog from 12 to 13 canonical skills:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TigerKit 20.1.5
+# TigerKit 20.1.6
 
 <p align="center">
   <img src="assets/tigerkit-cover.png" width="960" alt="TigerKit Agent Skills 표지">
@@ -8,7 +8,7 @@ TigerKit은 Claude Code, Codex, Hermes Agent용 소규모 엔지니어링 Agent 
 모음입니다. 중앙 workflow runtime 없이 13개 self-contained skill을
 `npx skills`로 배포합니다. Decision closure, spec, ticket, implementation은
 각각 하나의 canonical phase skill이 소유하고 `tk-drive`가 그 결과를
-단방향으로 오케스트레이션합니다. 최신 immutable release는 `v20.1.5`이며,
+단방향으로 오케스트레이션합니다. 최신 immutable release는 `v20.1.6`이며,
 현재 `main`에는 다음 release를 위한 orchestration 변경이 포함될 수 있습니다.
 
 ## 설치
@@ -36,10 +36,10 @@ npx skills add MTGVim/tiger-kit \
   --skill tk-browser-verify
 ```
 
-변경되지 않는 `v20.1.5` snapshot:
+변경되지 않는 `v20.1.6` snapshot:
 
 ```bash
-npx skills add "MTGVim/tiger-kit#v20.1.5" \
+npx skills add "MTGVim/tiger-kit#v20.1.6" \
   --global \
   --agent claude-code \
   --agent codex \

--- a/evals/behavior-cases.yaml
+++ b/evals/behavior-cases.yaml
@@ -79,6 +79,9 @@
 - case: grill-me-keeps-one-question-at-a-time
   skill: tk-grill-me
   expect: "Only one highest-impact user decision question is asked at a time."
+- case: grill-uses-native-question-tool
+  skill: tk-grill-me
+  expect: "When a native structured user-input tool is exposed, call it and proactively use relevant preview/prototype support; make Question explain evidence-derived context and impact before two or three proposals with tradeoffs and exactly one localized recommendation marker, and use prose only when no such tool is exposed, never after tool failure or rejection."
 - case: grill-me-researches-facts-before-asking
   skill: tk-grill-me
   expect: "Facts available in code or environment are researched before asking the user."

--- a/scripts/test_validate_skills.py
+++ b/scripts/test_validate_skills.py
@@ -17,6 +17,7 @@ if __package__:
         validate_release_version_contract,
         validate_runtime_scratch,
         validate_skill_language,
+        validate_user_decision_contract,
         validate_skill,
         validate_skill_eval_files,
     )
@@ -32,6 +33,7 @@ else:
         validate_release_version_contract,
         validate_runtime_scratch,
         validate_skill_language,
+        validate_user_decision_contract,
         validate_skill,
         validate_skill_eval_files,
     )
@@ -75,6 +77,7 @@ class CanonicalSkillContractTest(unittest.TestCase):
                 "drive-reads-complete-remote-source",
                 "grill-accepts-active-drive-handoff",
                 "grill-returns-control-to-drive",
+                "grill-uses-native-question-tool",
                 "to-spec-returns-decision-blocker-to-drive",
                 "to-spec-blocks-source-current-ui-mismatch",
                 "to-tickets-returns-decision-blocker-to-drive",
@@ -140,6 +143,60 @@ class CanonicalSkillContractTest(unittest.TestCase):
         root = Path(__file__).resolve().parents[1]
 
         self.assertEqual(validate_skill_language(root), [])
+
+    def test_canonical_skills_embed_native_user_decision_contract(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        required = (
+            "## User decision questions",
+            "Render `Question` before `Recommendation` and the proposals.",
+            "evidence-derived context, decision impact, and unresolved axis",
+            "must not require the user to decode raw `Evidence`",
+            "two or three mutually exclusive proposals",
+            "exactly one best recommendation",
+            "`(Recommended)` or `(추천)`",
+            "option previews, prototype cards, or equivalent",
+            "use it proactively",
+            "must call that tool",
+            "Plain-text questions are allowed only",
+            "failed or rejected tool call",
+            "Claude Code: `AskUserQuestion`",
+            "Codex: `request_user_input`",
+            "Hermes Agent: `clarify`",
+        )
+
+        for skill in EXPECTED_SKILLS:
+            with self.subTest(skill=skill):
+                text = (root / "skills" / skill / "SKILL.md").read_text(
+                    encoding="utf-8"
+                )
+                self.assertTrue(
+                    all(token in text for token in required),
+                    f"{skill} is missing the native user-decision question contract",
+                )
+        self.assertEqual(validate_user_decision_contract(root), [])
+
+    def test_user_decision_contract_gate_rejects_one_weakened_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_root = Path(__file__).resolve().parents[1]
+            for skill in EXPECTED_SKILLS:
+                target = root / "skills" / skill / "SKILL.md"
+                target.parent.mkdir(parents=True)
+                text = (
+                    source_root / "skills" / skill / "SKILL.md"
+                ).read_text(encoding="utf-8")
+                if skill == "tk-prototype":
+                    text = text.replace(
+                        "Codex: `request_user_input`",
+                        "Codex: ask in prose",
+                    )
+                target.write_text(text, encoding="utf-8")
+
+            errors = validate_user_decision_contract(root)
+
+            self.assertEqual(len(errors), 1)
+            self.assertIn("tk-prototype", errors[0])
+            self.assertIn("Codex: `request_user_input`", errors[0])
 
     def test_skill_language_validator_rejects_mixed_operational_prose(
         self,

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -48,6 +48,23 @@ TERMINAL_STATUSES = {
     "NotApplicable",
 }
 SUPPORTED_EVAL_HOSTS = {"claude-code", "codex", "hermes-agent"}
+USER_DECISION_CONTRACT_TOKENS = (
+    "## User decision questions",
+    "Render `Question` before `Recommendation` and the proposals.",
+    "evidence-derived context, decision impact, and unresolved axis",
+    "must not require the user to decode raw `Evidence`",
+    "two or three mutually exclusive proposals",
+    "exactly one best recommendation",
+    "`(Recommended)` or `(추천)`",
+    "option previews, prototype cards, or equivalent",
+    "use it proactively",
+    "must call that tool",
+    "Plain-text questions are allowed only",
+    "failed or rejected tool call",
+    "Claude Code: `AskUserQuestion`",
+    "Codex: `request_user_input`",
+    "Hermes Agent: `clarify`",
+)
 CATALOG_ROUTING_BOUNDARIES = {
     "tk-to-spec vs tk-to-tickets",
     "tk-reflect vs tk-grooming",
@@ -115,6 +132,7 @@ REQUIRED_BEHAVIOR_CASES = {
     "browser-interactive-auth-only-headed-exception",
     "browser-captures-move-to-tigerkit-ledger",
     "grill-me-keeps-one-question-at-a-time",
+    "grill-uses-native-question-tool",
     "grill-me-researches-facts-before-asking",
     "grill-me-does-not-write-domain-docs",
     "grill-me-does-not-create-adrs",
@@ -339,6 +357,23 @@ def validate_local_only_workflows(root: Path) -> list[str]:
     return errors
 
 
+def validate_user_decision_contract(root: Path) -> list[str]:
+    errors: list[str] = []
+    for skill in sorted(EXPECTED_SKILLS):
+        path = root / "skills" / skill / "SKILL.md"
+        if not path.is_file():
+            errors.append(f"{skill}: SKILL.md: add the native user-decision question contract")
+            continue
+        text = path.read_text(encoding="utf-8")
+        missing = [token for token in USER_DECISION_CONTRACT_TOKENS if token not in text]
+        if missing:
+            errors.append(
+                f"{skill}: SKILL.md: native user-decision question contract missing "
+                + ", ".join(repr(token) for token in missing)
+            )
+    return errors
+
+
 def validate_skill(path: Path) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -491,6 +526,7 @@ def validate_repository_contract() -> list[str]:
             errors.append(f"{relative}: required TigerKit 20.1.5 repository file is missing")
     errors.extend(validate_local_only_workflows(ROOT))
     errors.extend(validate_skill_language(ROOT))
+    errors.extend(validate_user_decision_contract(ROOT))
     for relative in (".claude-plugin", "commands", "hooks", "docs/tigerkit", "package.json"):
         if (ROOT / relative).exists():
             errors.append(f"{relative}: remove legacy/runtime surface from TigerKit 20.1.5")

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -523,20 +523,20 @@ def validate_repository_contract() -> list[str]:
     )
     for relative in required_files:
         if not (ROOT / relative).is_file():
-            errors.append(f"{relative}: required TigerKit 20.1.5 repository file is missing")
+            errors.append(f"{relative}: required TigerKit 20.1.6 repository file is missing")
     errors.extend(validate_local_only_workflows(ROOT))
     errors.extend(validate_skill_language(ROOT))
     errors.extend(validate_user_decision_contract(ROOT))
     for relative in (".claude-plugin", "commands", "hooks", "docs/tigerkit", "package.json"):
         if (ROOT / relative).exists():
-            errors.append(f"{relative}: remove legacy/runtime surface from TigerKit 20.1.5")
+            errors.append(f"{relative}: remove legacy/runtime surface from TigerKit 20.1.6")
     errors.extend(validate_runtime_scratch(ROOT))
     ignored = (ROOT / ".gitignore").read_text(encoding="utf-8") if (ROOT / ".gitignore").is_file() else ""
     if ".tigerkit/" not in ignored.splitlines():
         errors.append(".gitignore: document TigerKit repo-local scratch with .tigerkit/")
     required_text = {
         "README.md": (
-            "TigerKit 20.1.5",
+            "TigerKit 20.1.6",
             "13",
             "Claude Code",
             "Codex",
@@ -545,7 +545,7 @@ def validate_repository_contract() -> list[str]:
             "사용 시나리오",
         ),
         "MIGRATION.md": (
-            "TigerKit 20.1.5",
+            "TigerKit 20.1.6",
             "Removed Skills",
             "model-only",
             "hybrid",

--- a/skills/tk-browser-verify/SKILL.md
+++ b/skills/tk-browser-verify/SKILL.md
@@ -211,6 +211,36 @@ add `## Receipt` or duplicate facts. Omit empty Findings/Unverified/Cleanup.
 User-facing progress and receipt prose follows the user's language while the
 canonical headings, fields, and status tokens above remain unchanged.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not call an auto-browser without launch configuration and exact

--- a/skills/tk-drive/SKILL.md
+++ b/skills/tk-drive/SKILL.md
@@ -136,6 +136,36 @@ first assert that every consumed success receipt has its next transition.
 Write user-facing progress updates and the final receipt in the user's language,
 while preserving canonical status and receipt field names.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not start from an ordinary request, artifact, or generic continuation.

--- a/skills/tk-grill-me/SKILL.md
+++ b/skills/tk-grill-me/SKILL.md
@@ -52,7 +52,10 @@ confirmed evidence.
 3. `identify gaps`: compare facts and confirmed decisions against the
    Scope, Constraints, Outputs, and Verification ledger.
 4. `ask`: select the highest-impact unresolved user-owned decision and present
-   exactly one `Recommendation`, `Evidence`, and `Question`.
+   exactly one `Question`, `Recommendation`, and `Evidence`, in that order.
+   Make Question explain the evidence-derived context and decision impact in
+   readable user-facing language; keep raw paths, logs, and traceability in
+   Evidence below it.
 5. `incorporate answer`: preserve the answer as the corresponding Decision,
    Constraint, Out of scope, Output, or Verification entry.
 6. `repeat or close`: do not repeat answered questions; ask the next one or
@@ -80,9 +83,10 @@ safe-progress blocker, scope or irreversible-effect change, verification
 blocker, then downstream rework; break any remaining tie in ledger order.
 
 The ledger is not a per-turn dump template. On a question turn, report only
-new or changed evidence, the selected unresolved item, one Recommendation,
-Evidence, and Question, and `pending`. Repeat unchanged axes only when needed
-to explain a conflict or evaluate closure.
+new or changed evidence, the selected unresolved item, one Question,
+Recommendation, and Evidence in that order, and `pending`. Repeat unchanged
+axes only when needed to explain a conflict or evaluate closure.
+Question must remain understandable without reading the raw Evidence field.
 
 ## Facts and user judgment
 
@@ -149,6 +153,36 @@ the spec gate.
 
 Write user-facing questions and receipts in the user's language while
 preserving canonical fields and status tokens.
+
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
 
 ## DO NOT / ANTI-PATTERNS
 

--- a/skills/tk-grill-me/evals/evals.json
+++ b/skills/tk-grill-me/evals/evals.json
@@ -172,6 +172,26 @@
           "type": "git_head_unchanged"
         }
       ]
+    },
+    {
+      "id": "grill-uses-native-question-tool",
+      "path": "boundary",
+      "prompt": "/tk-grill-me 현재 host 실행 context에 native structured user-input tool과 option preview/prototype card 기능이 노출되어 있습니다. 배포 전략 결정을 물어야 합니다. prose 질문으로 우회하지 말고 host tool과 preview를 쓰며, Question 안에서 evidence 기반 맥락과 영향을 읽기 쉽게 설명한 다음 최대 3개 제안 중 정확히 하나를 (추천) 표시하고 제 답을 기다리세요.",
+      "expected_output": "노출된 host-native structured question tool과 결정에 유용한 preview/prototype 기능을 반드시 사용하고, Question 안에서 evidence-derived context·decision impact·unresolved axis를 읽기 쉽게 설명한 뒤 Recommendation을 보여 준다. 상호 배타적인 제안 2–3개와 tradeoff를 제공하고 정확히 하나만 localized recommendation marker로 표시한 뒤 Pending으로 멈춘다. 원시 Evidence를 읽어야만 질문을 이해하게 하지 않으며, 도구가 실제로 노출되지 않은 환경에서만 prose fallback을 허용하고 실패·거절은 부재로 취급하지 않는다.",
+      "assertions": [
+        {
+          "type": "judge",
+          "criterion": "현재 실행 context에 native structured user-input tool이 노출되면 이를 반드시 호출하며 prose로 우회하지 않는다. 노출된 option preview/prototype 기능이 결정을 구체화하면 적극 사용한다. Question이 Recommendation보다 먼저 나오고 evidence-derived context, decision impact, unresolved axis를 읽기 쉽게 설명하여 원시 Evidence 해독을 요구하지 않는다. 제안은 2–3개이며 tradeoff가 있고 정확히 하나만 (Recommended) 또는 (추천)으로 표시된다. plain-text fallback은 도구가 노출되지 않은 경우에만 허용하며 도구 실패나 거절을 부재로 간주하지 않는다."
+        },
+        {
+          "type": "terminal_status",
+          "expected": "Pending"
+        },
+        {
+          "type": "git_head_unchanged"
+        }
+      ],
+      "safety": true
     }
   ]
 }

--- a/skills/tk-grooming/SKILL.md
+++ b/skills/tk-grooming/SKILL.md
@@ -149,6 +149,36 @@ Do not start `--apply` mutation before the audit receipt identifies evidence
 and allowed scope. Ambiguous scope or missing reference evidence for
 delete/move stops `Partial/Blocked | Unverifiable`.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not mutate without apply authority or skip reference checks for

--- a/skills/tk-handoff/SKILL.md
+++ b/skills/tk-handoff/SKILL.md
@@ -120,6 +120,36 @@ automatically commit/publish.
 User-facing progress and receipt prose follows the user's language while
 canonical fields and status tokens remain unchanged.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not mark an unexecuted command, check, or decision

--- a/skills/tk-implement/SKILL.md
+++ b/skills/tk-implement/SKILL.md
@@ -278,6 +278,36 @@ repeating the body.
 Write user-facing progress and report prose in the user's language. Preserve
 the canonical headings, status tokens, IDs, and receipt keys above.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not bypass hooks outside the bounded byte-preservation or hook-config

--- a/skills/tk-learn/SKILL.md
+++ b/skills/tk-learn/SKILL.md
@@ -107,6 +107,36 @@ Before approval, each field has one owner:
 User-facing progress and receipt prose follows the user's language while
 canonical fields and status tokens remain unchanged.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not promote one-off cases, credentials, raw logs, or screenshots into

--- a/skills/tk-merge-conflict/SKILL.md
+++ b/skills/tk-merge-conflict/SKILL.md
@@ -111,6 +111,36 @@ and references. Push requires a separate request.
 User-facing progress and receipt prose follows the user's language while
 canonical headings and status tokens remain unchanged.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not choose one side or invent behavior without evidence.

--- a/skills/tk-prototype/SKILL.md
+++ b/skills/tk-prototype/SKILL.md
@@ -103,6 +103,36 @@ aesthetic preference into a conclusion.
 User-facing progress and receipt prose follows the user's language while
 canonical headings and status tokens remain unchanged.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not call a prototype production-ready or auto-promote/commit it.

--- a/skills/tk-reflect/SKILL.md
+++ b/skills/tk-reflect/SKILL.md
@@ -183,6 +183,36 @@ add evidence during a formatting-only reprint.
 User-facing progress and receipt prose follows the user's language while
 canonical headings, IDs, fields, and status tokens remain unchanged.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not present interpretation as fact or inflate confidence.

--- a/skills/tk-skill-diagnose/SKILL.md
+++ b/skills/tk-skill-diagnose/SKILL.md
@@ -158,6 +158,36 @@ separate from terminal status:
 Write user-facing progress and receipt prose in the user's language. Preserve
 canonical headings, IDs, enums, and status tokens.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not assume every incident is a SKILL.md wording defect.

--- a/skills/tk-to-spec/SKILL.md
+++ b/skills/tk-to-spec/SKILL.md
@@ -127,6 +127,36 @@ uncheckable UI literals are `Unverifiable`. Never save them as `Ready`.
 Write user-facing progress and receipt prose in the user's language. Preserve
 canonical status tokens, IDs, and receipt keys.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not mix facts, decisions, and assumptions without a source map or choose

--- a/skills/tk-to-tickets/SKILL.md
+++ b/skills/tk-to-tickets/SKILL.md
@@ -133,6 +133,36 @@ create or overwrite tickets; return `Unresolved split report`, `Blocked`, or
 Write user-facing progress and receipt prose in the user's language. Preserve
 canonical status tokens, IDs, and receipt keys.
 
+## User decision questions
+
+When this skill reaches a user-owned decision, ask exactly one question at a
+time. Render `Question` before `Recommendation` and the proposals. Offer
+two or three mutually exclusive proposals and state the material tradeoff of
+each. Make `Question` self-contained: summarize the
+evidence-derived context, decision impact, and unresolved axis in user-facing
+language before asking. It must not require the user to decode raw `Evidence`.
+Mark exactly one best recommendation by ending its label with a localized marker such as
+`(Recommended)` or `(추천)`. A host-generated custom or Other choice does not
+count as an authored proposal.
+
+When the active question tool exposes
+option previews, prototype cards, or equivalent rich choice surfaces and a concrete preview can clarify the
+decision, use it proactively. Do not invent unsupported fields or use this
+presentation rule to bypass existing prototype or phase boundaries.
+
+If the current execution context exposes a native structured user-input tool,
+the skill must call that tool. Plain-text questions are allowed only when no
+such tool is exposed. A failed or rejected tool call is not tool absence: report
+the failure and preserve the pending or blocked state instead of silently
+downgrading to prose. Host examples:
+
+- Claude Code: `AskUserQuestion`
+- Codex: `request_user_input`
+- Hermes Agent: `clarify`
+
+This contract changes question presentation only. It does not grant new
+decision authority or weaken any existing stop, approval, or phase boundary.
+
 ## DO NOT / ANTI-PATTERNS
 
 - Do not create horizontal type/API/UI/test-only tickets or unsupported


### PR DESCRIPTION
## Summary

- standardize readable structured user-decision questions across all 13 canonical skills
- require native host question tools when available, with Claude Code, Codex, and Hermes Agent examples
- place `Question` before `Recommendation`, bound proposals to two or three, and mark exactly one recommendation
- add validator, unit, and behavior-eval gates for tool use, ordering, readability, previews, and fallback behavior
- align active version metadata and release documentation to v20.1.6

## Local release evidence

Exact candidate: `5ebd8f214853596a5d1d71c5d86e31fac1a9ed08`

- `python3 scripts/validate_skills.py` — 13 skills, 0 errors
- `python3 scripts/validate_skills.py --links-only` — 0 errors
- `python3 scripts/sync_eval_compat.py` — 13 Darwin projections valid
- `(cd scripts && python3 -m unittest)` — 59 tests, OK
- `npx --yes skills@1.5.9 add . --list` — 13 skills
- `npx --yes skills add . --list` — 13 skills
- temporary copy install — Claude Code, Codex, Hermes Agent: 13 skills each, no symlinks
- `git diff --check` and staged secret/scratch inspection — clean

Live behavioral eval was not designated as a release gate; no live-eval result is claimed.

## Issues

Issues: none