### PR TITLE
chore: one-off merged branch cleanup

### DIFF
--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - auto-optimize/20260729-122439
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 permissions:
   contents: write
@@ -16,7 +23,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          SELF_BRANCH: ${{ github.ref_name }}
+          SELF_BRANCH: ${{ github.head_ref || github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail
@@ -60,5 +67,5 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          SELF_BRANCH: ${{ github.ref_name }}
+          SELF_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${SELF_BRANCH}"

--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -1,0 +1,64 @@
+name: One-off merged branch cleanup
+
+on:
+  push:
+    branches:
+      - auto-optimize/20260729-122439
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete branches fully merged into main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SELF_BRANCH: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo="$GITHUB_REPOSITORY"
+          default="$DEFAULT_BRANCH"
+          self="$SELF_BRANCH"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          git -C "$tmp" init -q
+          git -C "$tmp" remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git"
+          git -C "$tmp" fetch -q --no-tags --prune origin '+refs/heads/*:refs/remotes/origin/*'
+
+          deleted=0
+          kept=0
+          failed=0
+
+          while IFS= read -r branch; do
+            if [[ "$branch" == "$default" || "$branch" == "$self" ]]; then
+              continue
+            fi
+
+            if git -C "$tmp" merge-base --is-ancestor "refs/remotes/origin/$branch" "refs/remotes/origin/$default"; then
+              if gh api --method DELETE "repos/${repo}/git/refs/heads/${branch}" >/dev/null; then
+                echo "DELETED $branch"
+                deleted=$((deleted + 1))
+              else
+                echo "FAILED $branch"
+                failed=$((failed + 1))
+              fi
+            else
+              echo "KEPT_UNMERGED $branch"
+              kept=$((kept + 1))
+            fi
+          done < <(git -C "$tmp" for-each-ref --format='%(refname:strip=3)' refs/remotes/origin | sort)
+
+          echo "SUMMARY deleted=$deleted kept_unmerged=$kept failed=$failed"
+
+      - name: Delete cleanup branch
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SELF_BRANCH: ${{ github.ref_name }}
+        run: gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${SELF_BRANCH}"


### PR DESCRIPTION
Temporary maintenance PR used only to execute a one-off cleanup of remote branches whose heads are already ancestors of `main`.

- `main` is excluded.
- The cleanup branch is excluded during the scan and deletes itself after the run.
- Branches not fully merged into `main` are retained.
- This PR will not be merged.