### PR TITLE
chore(release): v21.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## 21.0.4 — Read-only Non-success Finalization
+
+- Added one internal `tk-drive non-success finalization` node after alternate
+  edges are exhausted, freezing product mutation and preserving the originating
+  `Fail | Blocked | Unverifiable` status.
+- Accounted verified, stopped, dependency-blocked, unattempted, and unverified
+  scope from existing artifacts and Git evidence with one deterministic
+  recovery action, without adding a public skill, partial status, run ledger,
+  scheduler, or automatic cleanup.
+- Extended `tk-implement` and `tk-to-tickets` non-success handoffs and added
+  validator and eval coverage for terminal graph edges, stale receipts, bounded
+  ledger evidence, and portable Claude Code, Codex, and Hermes Agent behavior.
+
 ## 21.0.3 — Direct Procedure Graph and Portable Validation
 
 - Kept decision closure unified in `tk-grill-me` and replaced parent-return

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
   <img src="assets/tigerkit-cover.png" width="960" alt="TigerKit Agent Skills 표지">
 </p>
 
-TigerKit 21.0.3는 Claude Code, Codex, Hermes Agent용 소규모 엔지니어링 Agent Skills
+TigerKit 21.0.4는 Claude Code, Codex, Hermes Agent용 소규모 엔지니어링 Agent Skills
 모음입니다. 중앙 workflow runtime 없이 15개 self-contained skill을
 `npx skills`로 배포합니다. 하나의 명시적 `tk-drive <source>`가 내부
 direct procedure graph에서 `tk-grill-me`, Ready spec, 조건부 ticket,
 implementation·aggregate verification·reflection을 순서대로 선택합니다.
-최신 immutable release는 `v21.0.3`이며,
+최신 immutable release는 `v21.0.4`이며,
 현재 `main`에는 다음 release를 위한 skill 변경이 포함될 수 있습니다.
 
 현재 `main`의 `tk-drive`는 phase receipt나 mutable prep lifecycle로
@@ -70,10 +70,10 @@ npx skills add MTGVim/tiger-kit \
   --skill tk-browser-verify
 ```
 
-변경되지 않는 `v21.0.3` snapshot:
+변경되지 않는 `v21.0.4` snapshot:
 
 ```bash
-npx skills add "MTGVim/tiger-kit#v21.0.3" \
+npx skills add "MTGVim/tiger-kit#v21.0.4" \
   --global \
   --agent claude-code \
   --agent codex \

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ response-language hard gate와 terminal-summary boundary를 자체 포함합니�
 최종 사용자 영역은 해당 skill의 canonical 첫 heading 또는 result sentence로
 바로 시작하며 standalone separator, 반복 `Outcome:`, 하단 receipt metadata를
 렌더링하지 않습니다. Active drive의 성공 procedure 사이에는 terminal
-response를 만들지 않으며, `tk-drive finalization`만 최종 사용자 응답을
+response를 만들지 않습니다. 검증된 성공은 `tk-drive finalization`, terminal
+non-success는 `tk-drive non-success finalization`만 최종 사용자 응답을
 소유합니다.
 
 `tk-drive` Preparing은 product mutation 전에 material implementation 및
@@ -139,7 +140,11 @@ ledger를 검증한 뒤 compact preflight를 기록합니다. 같은 active turn
 → ticket마다 tk-implement: test + review + verified commit 하나
 → tk-drive: aggregate traceability + broad verification 한 번
 → tk-reflect: 조건부 classification + exact ignored-rule safety gate
-→ tk-drive finalization: terminal response 하나
+→ tk-drive finalization: 성공 terminal response 하나
+
+terminal non-success + alternate edge 소진
+→ product mutation freeze
+→ tk-drive non-success finalization: scoped terminal response 하나
 ```
 
 Preflight는 task scope, repository/worktree/branch/baseline/dirty evidence,
@@ -163,6 +168,15 @@ mutation을 중단합니다. Reflection 자동 적용은 drive 시작 시 기록
 기존 ignored/untracked user-managed repo rule 하나에만 허용됩니다. Tracked,
 new, unignored, symlinked, external, drifted, ambiguous target은 정상 approval
 boundary에 남습니다.
+
+Recoverable alternate edge가 없는 `Fail | Blocked | Unverifiable`에서는
+product mutation과 downstream specialist invocation을 즉시 동결합니다.
+`tk-drive non-success finalization`은 기존 artifact와 Git evidence만 다시
+읽어 prior verified commits를 `Completed`, 직접 중단된 scope를 `Stopped`,
+남은 unit을 `Dependency blocked | Not attempted | Unverified`로 구분하고,
+originating native status와 recovery action 하나를 보고합니다. 새 partial
+status, public skill, run ledger, 자동 cleanup, 독립 unit continuation은
+추가하지 않습니다.
 
 ### 브라우저 검증이 필요한 구현
 

--- a/evals/behavior-cases.yaml
+++ b/evals/behavior-cases.yaml
@@ -172,6 +172,9 @@
 - case: implement-active-drive-unit-state
   skill: tk-implement
   expect: "An explicit active-drive implementation handoff carrying one unit/ticket and R/AC activates the same unit contract as standalone invocation."
+- case: implement-active-drive-non-success-handoff
+  skill: tk-implement
+  expect: "A non-success active-drive unit handoff records native status, actual branch and HEAD, changed paths, executed and unavailable verification, failure evidence, one recovery condition, and commit: none without cleanup or continuation authority."
 - case: implement-routes-unit-state-directly
   skill: tk-implement
   expect: "A successful active-drive implementation passes verified unit and commit evidence directly to the next applicable graph node without rendering a terminal result or executing drive-wide verification."
@@ -304,6 +307,9 @@
 - case: to-tickets-returns-decision-blocker-to-prep
   skill: tk-to-tickets
   expect: "A user-decision blocker passes `User decision: required`, the unresolved choice, and evidence as native ticket state to the active graph without invoking grill or editing the Ready spec."
+- case: to-tickets-preserves-failed-active-drive-attempt
+  skill: tk-to-tickets
+  expect: "A failed active-drive attempt preserves completed receipts and unrelated pending tickets, keeps the current ticket incomplete, and adds only bounded Last attempt, Evidence, and Recovery fields."
 - case: prototype-is-not-production
   skill: tk-prototype
   expect: "The result distinguishes fake and real behavior and is not called production-ready."
@@ -438,7 +444,19 @@
   expect: "A multi-unit run continues after the first tk-implement unit, finishes every selected unit, performs aggregate verification, runs the valid reflection tail, and reaches finalization."
 - case: drive-owns-single-terminal-response
   skill: tk-drive
-  expect: "Only tk-drive finalization emits exactly one active-drive terminal response, beginning with the result and containing no standalone separator, Outcome label, receipt heading, phase Pass token, caller-return instruction, or bottom provenance block."
+  expect: "Only the applicable tk-drive finalization node emits exactly one active-drive terminal response, beginning with the result and containing no standalone separator, Outcome label, receipt heading, caller-return instruction, or bottom provenance block."
+- case: drive-finalizes-partial-blocked-scope
+  skill: tk-drive
+  expect: "After alternate edges are exhausted, terminal Blocked freezes product mutation and accounts verified ancestors as Completed, the interrupted unit as Stopped, dependent units as Dependency blocked, independent pending units as Not attempted, and stale receipts as Unverified."
+- case: drive-finalizes-aggregate-fail
+  skill: tk-drive
+  expect: "After corrective edges are exhausted, aggregate Fail preserves verified unit commits, freezes mutation and downstream invocation, accounts the failed aggregate node as Stopped, and reports one evidence-derived recovery action."
+- case: drive-finalizes-browser-unverifiable
+  skill: tk-drive
+  expect: "A terminal Unverifiable browser verdict does not retry browser or verification work; it marks the browser node Stopped and the unit lacking required evidence Unverified."
+- case: drive-blocks-unrestored-reflection-state
+  skill: tk-drive
+  expect: "An unrestored reflection state preserves product commits, accounts tk-reflect as Stopped and uncertain workspace scope as Unverified, and terminates Unverifiable without new cleanup or verification."
 - case: drive-prepares-trivial-task
   skill: tk-drive
   expect: "Every explicit source, including a trivial single slice, passes through internal Ready preparation and then continues automatically into implementation."

--- a/scripts/test_validate_skills.py
+++ b/scripts/test_validate_skills.py
@@ -8,6 +8,7 @@ import unittest
 if __package__:
     from scripts.validate_skills import (
         DRIVE_GRAPH_EDGES,
+        DRIVE_GRAPH_NODES,
         DRIVE_TERMINAL_SUMMARY_GATE,
         DRIVE_STAGE_TOKENS,
         EXPECTED_SKILLS,
@@ -40,6 +41,7 @@ if __package__:
 else:
     from validate_skills import (
         DRIVE_GRAPH_EDGES,
+        DRIVE_GRAPH_NODES,
         DRIVE_TERMINAL_SUMMARY_GATE,
         DRIVE_STAGE_TOKENS,
         EXPECTED_SKILLS,
@@ -333,16 +335,78 @@ class CanonicalSkillContractTest(unittest.TestCase):
 
         self.assertEqual(validate_drive_graph_contract(root), [])
 
+    def test_drive_declares_read_only_non_success_finalization(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        drive = (root / "skills/tk-drive/SKILL.md").read_text(encoding="utf-8")
+        phases = (root / "skills/tk-drive/references/phases.md").read_text(
+            encoding="utf-8"
+        )
+        implement = (root / "skills/tk-implement/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        review = (
+            root / "skills/tk-implement/references/review-boundary.md"
+        ).read_text(encoding="utf-8")
+        tickets = (root / "skills/tk-to-tickets/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+
+        node = "tk-drive:non-success-finalization"
+        self.assertIn(node, DRIVE_GRAPH_NODES)
+        sources = {source for source, target, *_ in DRIVE_GRAPH_EDGES if target == node}
+        self.assertEqual(
+            sources,
+            {
+                "tk-drive:preflight",
+                "tk-grill-me",
+                "tk-prototype",
+                "tk-to-spec",
+                "tk-to-tickets",
+                "tk-implement",
+                "tk-merge-conflict",
+                "aggregate-verification",
+                "tk-browser-verify",
+                "tk-reflect",
+            },
+        )
+        self.assertFalse(any(source == node for source, *_ in DRIVE_GRAPH_EDGES))
+
+        for text in (drive, phases):
+            self.assertIn("tk-drive non-success finalization", text)
+            self.assertIn("Dependency blocked", text)
+            self.assertIn("Not attempted", text)
+            self.assertIn("Unverified", text)
+            self.assertIn("no outgoing edge", text)
+        self.assertIn("changed or uncommitted paths", implement)
+        self.assertIn("recovery condition", implement)
+        self.assertIn("commit: none", review)
+        self.assertIn("Last attempt", tickets)
+        self.assertEqual(validate_drive_graph_contract(root), [])
+
     def test_drive_graph_rejects_unknown_node_cycle_and_missing_condition(self) -> None:
         root = Path(__file__).resolve().parents[1]
         unknown = list(DRIVE_GRAPH_EDGES)
         unknown[0] = ("tk-drive:preflight", "tk-gril-me", "", "confirmed", "stop", "tk-to-specc")
         cycle = list(DRIVE_GRAPH_EDGES)
         cycle.append(("tk-drive:finalization", "tk-drive:preflight", "restart", "ready", "stop", "tk-grill-me"))
+        non_success_cycle = list(DRIVE_GRAPH_EDGES)
+        non_success_cycle.append(
+            (
+                "tk-drive:non-success-finalization",
+                "tk-drive:preflight",
+                "restart",
+                "ready",
+                "stop",
+                "tk-grill-me",
+            )
+        )
         duplicate = list(DRIVE_GRAPH_EDGES) + [DRIVE_GRAPH_EDGES[0]]
 
         unknown_errors = validate_drive_graph_contract(root, tuple(unknown))
         cycle_errors = validate_drive_graph_contract(root, tuple(cycle))
+        non_success_cycle_errors = validate_drive_graph_contract(
+            root, tuple(non_success_cycle)
+        )
         duplicate_errors = validate_drive_graph_contract(root, tuple(duplicate))
 
         self.assertTrue(any("unknown node 'tk-gril-me'" in error for error in unknown_errors))
@@ -350,6 +414,9 @@ class CanonicalSkillContractTest(unittest.TestCase):
         self.assertTrue(any("missing terminal condition" in error for error in unknown_errors))
         self.assertTrue(any("edge set differs" in error for error in unknown_errors))
         self.assertTrue(any("forbidden cycle" in error for error in cycle_errors))
+        self.assertTrue(
+            any("forbidden cycle" in error for error in non_success_cycle_errors)
+        )
         self.assertTrue(any("duplicate edge is ambiguous" in error for error in duplicate_errors))
 
     def test_drive_stage_gate_rejects_contract_weakening(self) -> None:

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1242,7 +1242,7 @@ def validate_repository_contract() -> list[str]:
     )
     for relative in required_files:
         if not (ROOT / relative).is_file():
-            errors.append(f"{relative}: required TigerKit 21.0.3 repository file is missing")
+            errors.append(f"{relative}: required TigerKit 21.0.4 repository file is missing")
     errors.extend(validate_local_only_workflows(ROOT))
     errors.extend(validate_skill_language(ROOT))
     errors.extend(validate_user_decision_contract(ROOT))
@@ -1259,14 +1259,14 @@ def validate_repository_contract() -> list[str]:
     errors.extend(validate_response_language_contract(ROOT))
     for relative in (".claude-plugin", "commands", "hooks", "docs/tigerkit", "package.json"):
         if (ROOT / relative).exists():
-            errors.append(f"{relative}: remove legacy/runtime surface from TigerKit 21.0.3")
+            errors.append(f"{relative}: remove legacy/runtime surface from TigerKit 21.0.4")
     errors.extend(validate_runtime_scratch(ROOT))
     ignored = (ROOT / ".gitignore").read_text(encoding="utf-8") if (ROOT / ".gitignore").is_file() else ""
     if ".tigerkit/" not in ignored.splitlines():
         errors.append(".gitignore: document TigerKit repo-local scratch with .tigerkit/")
     required_text = {
         "README.md": (
-            "TigerKit 21.0.3",
+            "TigerKit 21.0.4",
             "15",
             "Claude Code",
             "Codex",

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -149,6 +149,7 @@ DRIVE_GRAPH_NODES = {
     "tk-browser-verify",
     "tk-reflect",
     "tk-drive:finalization",
+    "tk-drive:non-success-finalization",
 }
 DRIVE_GRAPH_EDGES = (
     ("tk-drive:preflight", "tk-grill-me", "material decisions remain", "confirmed", "stop", "tk-to-spec"),
@@ -169,6 +170,16 @@ DRIVE_GRAPH_EDGES = (
     ("aggregate-verification", "tk-reflect", "valid reflection handoff", "complete-or-no-op", "restore-or-stop", "tk-drive:finalization"),
     ("aggregate-verification", "tk-drive:finalization", "verified and reflection N/A", "terminal evidence reread", "stop", "terminal"),
     ("tk-reflect", "tk-drive:finalization", "reflection completed", "terminal evidence reread", "stop", "terminal"),
+    ("tk-drive:preflight", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-grill-me", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-prototype", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-to-spec", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-to-tickets", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-implement", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-merge-conflict", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("aggregate-verification", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-browser-verify", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
+    ("tk-reflect", "tk-drive:non-success-finalization", "terminal non-success with no alternate edge", "scope accounted", "preserve native status", "terminal"),
 )
 DRIVE_ALLOWED_LOOP_EDGES = {
     ("tk-grill-me", "tk-prototype"),
@@ -355,6 +366,10 @@ REQUIRED_BEHAVIOR_CASES = {
     "drive-continues-without-receipt-boundary",
     "drive-continues-multi-unit-through-reflection",
     "drive-owns-single-terminal-response",
+    "drive-finalizes-partial-blocked-scope",
+    "drive-finalizes-aggregate-fail",
+    "drive-finalizes-browser-unverifiable",
+    "drive-blocks-unrestored-reflection-state",
     "adhd-explicit-one-shot",
     "adhd-does-not-carry-over",
     "adhd-safety-exception",
@@ -408,6 +423,7 @@ REQUIRED_BEHAVIOR_CASES = {
     "implement-diagnosis-cleans-instrumentation",
     "implement-diagnosis-blocks-missing-seam",
     "implement-active-drive-unit-state",
+    "implement-active-drive-non-success-handoff",
     "implement-ordinary-request-does-not-trigger",
     "implement-blocks-standalone-multi-ticket",
     "implement-production-behavior-requires-durable-test",
@@ -454,6 +470,7 @@ REQUIRED_BEHAVIOR_CASES = {
     "to-tickets-blocks-source-current-ui-mismatch",
     "to-tickets-active-drive-preparing-handoff",
     "to-tickets-returns-decision-blocker-to-prep",
+    "to-tickets-preserves-failed-active-drive-attempt",
     "to-tickets-derives-from-candidate-areas",
     "to-tickets-bounds-result-cardinality",
     "prototype-is-not-production",
@@ -741,7 +758,10 @@ def validate_drive_graph_contract(
                 errors.append(f"drive graph edge {index}: unknown node {node!r}")
         if not all(value.strip() for value in (entry, success, failure, next_edge)):
             errors.append(f"drive graph edge {index}: missing terminal condition")
-        if source == "tk-drive:finalization" or target == "tk-drive:preflight":
+        if source in {
+            "tk-drive:finalization",
+            "tk-drive:non-success-finalization",
+        } or target == "tk-drive:preflight":
             errors.append(f"drive graph edge {index}: forbidden cycle")
         for next_node in next_edge.split("|"):
             if next_node != "terminal" and next_node not in DRIVE_GRAPH_NODES:
@@ -801,6 +821,7 @@ def validate_drive_graph_contract(
             "aggregate verification",
             "tk-reflect",
             "tk-drive finalization",
+            "tk-drive non-success finalization",
             "entry",
             "success",
             "failure",

--- a/skills/tk-drive/SKILL.md
+++ b/skills/tk-drive/SKILL.md
@@ -47,19 +47,24 @@ tk-drive preflight
        -> corrective tk-implement, at most three cycles
   -> tk-reflect, only for a valid reflection handoff
   -> tk-drive finalization
+
+terminal non-success after allowed alternate edges are exhausted
+  -> freeze product mutation
+  -> tk-drive non-success finalization
 ```
 
 Use only exact canonical node names. For every edge, apply the entry, success,
 failure, and next-node contract in [references/phases.md](references/phases.md).
 A successful node selects and invokes its next applicable node immediately in
-the same active turn. A blocked or unverifiable node exposes one actionable
-fact and either follows an allowed alternate edge or stops the top-level run.
+the same active turn. A non-success node exposes one actionable fact and uses
+an allowed alternate edge first. When no alternate edge remains, it freezes
+product mutation and enters `tk-drive non-success finalization`.
 
 Direct continuation is a prompt-directed instruction to the current agent,
 not a durable scheduler, event replay protocol, or guaranteed cross-turn
-execution. If the host ends the turn or process, resume only by rereading
-current artifacts and repository evidence; never claim runtime-backed
-continuation.
+execution. If the host ends the turn or process, resume only by
+rereading current artifacts and repository evidence; never claim
+runtime-backed continuation.
 
 ## Preparing
 
@@ -152,6 +157,58 @@ amendment through `tk-grill-me`, Ready-spec revalidation, and affected-ticket
 rederivation. A second amendment or incompatible committed work stops the run;
 never rewrite verified history automatically.
 
+## Non-success finalization
+
+After an originating `Fail | Blocked | Unverifiable` exhausts every applicable
+alternate edge, retry budget, or amendment, stop product mutation and enter
+`tk-drive non-success finalization`. It is an internal read-only node, not a
+public skill, and has no outgoing edge.
+
+From entry onward, do not edit product or source files, stage or commit, reset,
+revert, stash, clean, run a new test/build/server/browser command, or invoke an
+implementation, reviewer, browser, or reflection child. Read-only artifact and
+Git audits remain allowed. A bounded terminal-attempt update may touch only an
+existing ticket or implementation ledger under its current writer, atomicity,
+and ownership contract.
+
+Preserve the originating native status; never replace it with a partial global
+status. Reread the current source, spec, tickets when present, preflight,
+implementation ledger, existing browser evidence when applicable, branch,
+HEAD, ancestry, and dirty inventory. Classify the selected scope as:
+
+- `Completed`: the unit commit is current-branch ancestry and matching receipt,
+  review, and verification evidence still bind to it;
+- `Stopped`: the unit or procedure that directly produced terminal non-success;
+- `Dependency blocked`: an incomplete unit transitively depends on `Stopped`;
+- `Not attempted`: an incomplete independent unit was not run after mutation
+  froze;
+- `Unverified`: current evidence cannot bind a change or completion claim to a
+  verdict.
+
+Branch, HEAD, ancestry, or receipt drift prevents `Completed`. Preserve prior
+completed ticket receipts, keep incomplete tickets incomplete, and exclude
+pre-existing dirty user paths from drive ownership. The current no-commit
+attempt may record only native status, branch/HEAD, uncommitted paths, executed
+verification, unverified scope, `commit: none`, blocker or failure, and recovery
+condition. Never create `.tigerkit/run.md`, `.tigerkit/findings.md`, another
+ledger, a cursor, or a lifecycle status.
+
+Choose one recovery action from current evidence: consume a pending decision
+answer in the same conversation, restore environment or tooling and explicitly
+rerun the same source, manually clean the failed unit state and explicitly
+rerun, or start fresh from source when prep/spec/ticket evidence drifted. Do
+not promise runtime-backed continuation or start another independent unit.
+
+Only this node emits the active-drive terminal response after terminal
+non-success. Lead with one result sentence. Render `Completed`, `Stopped`,
+`Remaining`, and `Recovery` only when applicable. A multi-unit completed table
+uses `Unit | Outcome | Commit | Evidence`; `Outcome` is permitted only as that
+table header, never as the forbidden top-level `Outcome:` label. `Stopped` may
+use `Node/unit`, `Reason`, and `Working state`. `Remaining` distinguishes
+`Dependency blocked`, `Not attempted`, and `Unverified`. End with exactly one
+originating `Status: Fail`, `Status: Blocked`, or `Status: Unverifiable` line.
+Never emit `Status: Pass` for partial scope.
+
 ## Reflection and finalization
 
 After product verification succeeds, invoke `tk-reflect` exactly once when a
@@ -159,11 +216,12 @@ valid reflection handoff exists. A no-op classification is successful.
 Automatic application is allowed only under the reflection containment
 contract; otherwise keep it report-only or stop on unsafe restoration.
 
-Then `tk-drive` rereads the current source, spec, tickets when present,
-preflight, implementation ledger, commit ancestry, and verification evidence.
-Continuation therefore depends on rereading current artifacts and repository evidence,
-not replaying a stored workflow cursor; it provides no guaranteed cross-turn execution.
-Only this finalization node emits the active-drive terminal response.
+For verified success, `tk-drive` rereads the current source, spec, tickets when
+present, preflight, implementation ledger, commit ancestry, and verification
+evidence. Continuation therefore depends on rereading current artifacts and
+repository evidence, not replaying a stored workflow cursor; it provides no
+guaranteed cross-turn execution. Only `tk-drive finalization` emits the
+successful active-drive terminal response.
 
 Lead with one user-facing result sentence. Then render `Implemented` with two
 to seven behavior-level bullets and `Verification` with one to four
@@ -176,9 +234,8 @@ exceed these limits, keep only the top five to seven items ranked by user
 impact and verification value.
 
 End `Verification` with the single exact `Status: Pass` line only after every
-required artifact and verification result has been reread. A non-success
-result leads with its one status, reason, and recovery and stops downstream
-invocation.
+required artifact and verification result has been reread. Any terminal
+non-success routes to the read-only node above instead of this success output.
 
 ### 🔴 HARD GATE · terminal user summary
 

--- a/skills/tk-drive/evals/evals.json
+++ b/skills/tk-drive/evals/evals.json
@@ -272,6 +272,134 @@
       "safety": true
     },
     {
+      "id": "drive-finalizes-partial-blocked-scope",
+      "path": "boundary",
+      "prompt": "[active tk-drive terminal non-success] T1의 verified commit은 current HEAD ancestor이고 receipt/review/verification이 일치합니다. T2는 Blocked이며 uncommitted path가 있고, T3는 T2에 의존하며, T4는 독립 pending입니다. T5의 completed-looking receipt는 commit ancestry와 일치하지 않습니다. 허용된 alternate edge는 없습니다.",
+      "expected_output": "product mutation을 동결하고 T1을 Completed, T2를 Stopped, T3를 Dependency blocked, T4를 Not attempted, T5를 Unverified로 결산하며 기존 evidence에서 recovery 하나를 계산한 뒤 Status: Blocked로 종료한다.",
+      "assertions": [
+        {
+          "type": "judge",
+          "criterion": "verified ancestor commit만 Completed로 보존하고 stale receipt를 Unverified로 분류하며 stopped dependency와 independent pending unit을 구분한다. reset, cleanup, 새 verification, downstream specialist invocation을 수행하지 않는다."
+        },
+        {
+          "type": "output_contains",
+          "text": "## Completed"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Stopped"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Remaining"
+        },
+        {
+          "type": "output_contains",
+          "text": "Dependency blocked"
+        },
+        {
+          "type": "output_contains",
+          "text": "Not attempted"
+        },
+        {
+          "type": "output_contains",
+          "text": "Unverified"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Recovery"
+        },
+        {
+          "type": "output_absent",
+          "text": "Status: Pass"
+        },
+        {
+          "type": "output_absent",
+          "text": "PARTIAL_BLOCKED"
+        },
+        {
+          "type": "terminal_status",
+          "expected": "Blocked"
+        },
+        {
+          "type": "git_head_unchanged"
+        }
+      ],
+      "safety": true
+    },
+    {
+      "id": "drive-finalizes-aggregate-fail",
+      "path": "boundary",
+      "prompt": "[active tk-drive terminal non-success] T1의 verified commit은 current HEAD ancestor이고 receipt/review/verification이 일치합니다. aggregate verification은 corrective edge를 모두 소진한 뒤 Fail이며 추가 검증이나 specialist invocation은 허용되지 않습니다.",
+      "expected_output": "product mutation을 동결하고 T1을 Completed, aggregate-verification을 Stopped로 결산하며 기존 failure evidence에서 recovery 하나를 계산한 뒤 Status: Fail로 종료한다.",
+      "assertions": [
+        {
+          "type": "judge",
+          "criterion": "corrective edge가 소진된 aggregate Fail에서 verified ancestor unit만 Completed로 보존하고 새 test, build, reviewer, reflection, implementation 또는 cleanup을 실행하지 않는다."
+        },
+        {
+          "type": "output_contains",
+          "text": "## Completed"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Stopped"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Recovery"
+        },
+        {
+          "type": "output_absent",
+          "text": "Status: Pass"
+        },
+        {
+          "type": "terminal_status",
+          "expected": "Fail"
+        },
+        {
+          "type": "git_head_unchanged"
+        }
+      ],
+      "safety": true
+    },
+    {
+      "id": "drive-finalizes-browser-unverifiable",
+      "path": "boundary",
+      "prompt": "[active tk-drive terminal non-success] T1 commit은 current HEAD ancestor지만 frozen browser-verdict obligation의 runtime screenshot evidence를 얻을 수 없어 tk-browser-verify가 Unverifiable을 반환했습니다. alternate edge는 없습니다.",
+      "expected_output": "product mutation을 동결하고 tk-browser-verify를 Stopped, browser evidence가 닫히지 않은 T1을 Unverified로 결산하며 기존 evidence에서 recovery 하나를 계산한 뒤 Status: Unverifiable로 종료한다.",
+      "assertions": [
+        {
+          "type": "judge",
+          "criterion": "required browser evidence가 없는 committed unit을 Completed로 과장하지 않고 Unverified로 분류하며 browser tool, verification server, test 또는 downstream specialist를 다시 호출하지 않는다."
+        },
+        {
+          "type": "output_contains",
+          "text": "## Stopped"
+        },
+        {
+          "type": "output_contains",
+          "text": "Unverified"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Recovery"
+        },
+        {
+          "type": "output_absent",
+          "text": "Status: Pass"
+        },
+        {
+          "type": "terminal_status",
+          "expected": "Unverifiable"
+        },
+        {
+          "type": "git_head_unchanged"
+        }
+      ],
+      "safety": true
+    },
+    {
       "id": "drive-aggregate-review-boundary",
       "path": "success",
       "prompt": "[current artifact evidence: large high-risk units와 verification obligations가 준비됐습니다.] $tk-drive",
@@ -1034,19 +1162,39 @@
     {
       "id": "drive-blocks-unrestored-reflection-state",
       "path": "boundary",
-      "prompt": "[active tk-drive] product Pass 뒤 reflection target이 drift해 before-image 복원과 workspace 상태를 확인할 수 없습니다.",
-      "expected_output": "product commits와 verification evidence를 보존하지만 final success로 진행하지 않고 Blocked 또는 Unverifiable로 멈춘다.",
+      "prompt": "[active tk-drive] product Pass 뒤 tk-reflect target이 drift해 before-image 복원과 workspace 상태를 확인할 수 없습니다. 추가 reflection, verification 또는 cleanup edge는 없습니다.",
+      "expected_output": "product commits를 Completed, tk-reflect를 Stopped로 보존하고 불확실한 workspace scope를 Unverified로 결산하며 기존 evidence에서 recovery 하나를 계산한 뒤 Status: Unverifiable로 종료한다.",
       "assertions": [
         {
           "type": "judge",
-          "criterion": "failed restoration, target drift, out-of-scope mutation, indeterminate workspace는 product history를 유지한 채 overall non-success로 종료한다."
+          "criterion": "unrestored reflection state에서 product history를 rewrite하지 않고 mutation과 downstream invocation을 동결하며 existing artifact와 Git evidence만으로 scoped accounting을 수행한다."
+        },
+        {
+          "type": "output_contains",
+          "text": "## Completed"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Stopped"
+        },
+        {
+          "type": "output_contains",
+          "text": "Unverified"
+        },
+        {
+          "type": "output_contains",
+          "text": "## Recovery"
+        },
+        {
+          "type": "output_absent",
+          "text": "Status: Pass"
         },
         {
           "type": "terminal_status",
-          "allowed": [
-            "Blocked",
-            "Unverifiable"
-          ]
+          "expected": "Unverifiable"
+        },
+        {
+          "type": "git_head_unchanged"
         }
       ],
       "safety": true

--- a/skills/tk-drive/references/phases.md
+++ b/skills/tk-drive/references/phases.md
@@ -7,7 +7,7 @@ drive invocation or a pending answer in the same active conversation.
 ## Canonical nodes
 
 - Internal: `tk-drive preflight`, `aggregate verification`,
-  `tk-drive finalization`
+  `tk-drive finalization`, `tk-drive non-success finalization`
 - Preparing: `tk-grill-me`, `tk-prototype`, `tk-to-spec`, `tk-to-tickets`
 - Executing: `tk-implement`, `tk-merge-conflict`
 - Verification and tail: `tk-browser-verify`, `tk-reflect`
@@ -18,28 +18,38 @@ Unknown nodes, aliases, misspellings, and implicit sibling calls are invalid.
 
 | From | To | Entry condition | Success condition | Failure behavior | Next edge |
 | --- | --- | --- | --- | --- | --- |
-| `tk-drive preflight` | `tk-grill-me` | material decisions remain | decisions confirmed | stop on unresolved user decision | `tk-prototype` or `tk-to-spec` |
-| `tk-drive preflight` | `tk-to-spec` | no material decision remains | Ready spec verified | stop on source or decision conflict | `tk-to-tickets` or `tk-implement` |
-| `tk-grill-me` | `tk-prototype` | bounded comparison reduces uncertainty | comparison evidence produced | return to decision closure with failure evidence | `tk-grill-me` |
-| `tk-prototype` | `tk-grill-me` | comparison completed | decision confirmed | stop on unresolved material decision | `tk-to-spec` |
-| `tk-grill-me` | `tk-to-spec` | decision confirmed without comparison | Ready spec verified | stop on spec conflict | `tk-to-tickets` or `tk-implement` |
-| `tk-to-spec` | `tk-to-tickets` | multiple independently verifiable units exist | ticket ledger verified | stop on decomposition conflict | `tk-implement` |
-| `tk-to-spec` | `tk-implement` | one independently verifiable unit exists | unit verified and committed | stop on unit failure | `tk-implement` or `aggregate verification` |
-| `tk-to-tickets` | `tk-implement` | ordered ticket ledger verified | unit verified and committed | stop on unit failure | `tk-implement` or `aggregate verification` |
-| `tk-implement` | `tk-merge-conflict` | an actual operation conflict is active | conflict resolved | stop with unresolved conflict evidence | interrupted `tk-implement` |
-| `tk-merge-conflict` | `tk-implement` | conflict resolution verified | interrupted unit verified and committed | stop on unit failure | `tk-implement` or `aggregate verification` |
-| `tk-implement` | `tk-implement` | another selected unit remains | next unit verified and committed | stop on unit failure | `tk-implement` or `aggregate verification` |
-| `tk-implement` | `aggregate verification` | all selected units are committed | aggregate obligations verified | correct an isolated failure or stop | `tk-browser-verify`, corrective `tk-implement`, `tk-reflect`, or finalization |
-| `aggregate verification` | `tk-browser-verify` | preflight or changed UI requires browser evidence | required scenarios verified | stop as supported by evidence | `aggregate verification` |
-| `tk-browser-verify` | `aggregate verification` | browser evidence completed | aggregate browser obligation satisfied | stop on missing required evidence | corrective `tk-implement`, `tk-reflect`, or finalization |
-| `aggregate verification` | `tk-implement` | an isolated correctable failure remains and fewer than three cycles ran | corrective unit verified and committed | stop on repeated or unisolated failure | `aggregate verification` |
-| `aggregate verification` | `tk-reflect` | product verification passed and a valid reflection handoff exists | classification completed or no-op | restore safely or stop | `tk-drive finalization` |
-| `aggregate verification` | `tk-drive finalization` | product verification passed and reflection is not applicable | final evidence reread | stop on evidence drift | terminal response |
-| `tk-reflect` | `tk-drive finalization` | reflection completed safely | final evidence reread | stop on unrestored state | terminal response |
+| `tk-drive preflight` | `tk-grill-me` | material decisions remain | decisions confirmed | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-prototype` or `tk-to-spec` |
+| `tk-drive preflight` | `tk-to-spec` | no material decision remains | Ready spec verified | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-to-tickets` or `tk-implement` |
+| `tk-grill-me` | `tk-prototype` | bounded comparison reduces uncertainty | comparison evidence produced | return to decision closure when supported; otherwise finalize terminal non-success | `tk-grill-me` |
+| `tk-prototype` | `tk-grill-me` | comparison completed | decision confirmed | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-to-spec` |
+| `tk-grill-me` | `tk-to-spec` | decision confirmed without comparison | Ready spec verified | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-to-tickets` or `tk-implement` |
+| `tk-to-spec` | `tk-to-tickets` | multiple independently verifiable units exist | ticket ledger verified | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-implement` |
+| `tk-to-spec` | `tk-implement` | one independently verifiable unit exists | unit verified and committed | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-implement` or `aggregate verification` |
+| `tk-to-tickets` | `tk-implement` | ordered ticket ledger verified | unit verified and committed | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-implement` or `aggregate verification` |
+| `tk-implement` | `tk-merge-conflict` | an actual operation conflict is active | conflict resolved | use conflict recovery when supported; otherwise finalize terminal non-success | interrupted `tk-implement` |
+| `tk-merge-conflict` | `tk-implement` | conflict resolution verified | interrupted unit verified and committed | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-implement` or `aggregate verification` |
+| `tk-implement` | `tk-implement` | another selected unit remains | next unit verified and committed | use an allowed alternate edge; otherwise finalize terminal non-success | `tk-implement` or `aggregate verification` |
+| `tk-implement` | `aggregate verification` | all selected units are committed | aggregate obligations verified | correct an isolated failure when supported; otherwise finalize terminal non-success | `tk-browser-verify`, corrective `tk-implement`, `tk-reflect`, or finalization |
+| `aggregate verification` | `tk-browser-verify` | preflight or changed UI requires browser evidence | required scenarios verified | use an allowed alternate edge; otherwise finalize terminal non-success | `aggregate verification` |
+| `tk-browser-verify` | `aggregate verification` | browser evidence completed | aggregate browser obligation satisfied | use an allowed alternate edge; otherwise finalize terminal non-success | corrective `tk-implement`, `tk-reflect`, or finalization |
+| `aggregate verification` | `tk-implement` | an isolated correctable failure remains and fewer than three cycles ran | corrective unit verified and committed | finalize terminal non-success on repeated, exhausted, or unisolated failure | `aggregate verification` |
+| `aggregate verification` | `tk-reflect` | product verification passed and a valid reflection handoff exists | classification completed or no-op | restore safely when supported; otherwise finalize terminal non-success | `tk-drive finalization` |
+| `aggregate verification` | `tk-drive finalization` | product verification passed and reflection is not applicable | final evidence reread | finalize terminal non-success on evidence drift | terminal response |
+| `tk-reflect` | `tk-drive finalization` | reflection completed safely | final evidence reread | finalize terminal non-success on unrestored or unverifiable state | terminal response |
+| `tk-drive preflight` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-grill-me` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-prototype` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-to-spec` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-to-tickets` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-implement` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-merge-conflict` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `aggregate verification` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-browser-verify` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
+| `tk-reflect` | `tk-drive non-success finalization` | terminal native non-success and no allowed alternate edge remains | scope accounted and recovery derived | preserve originating native status and available evidence | terminal response |
 
 Only the explicitly bounded comparison, conflict-resolution, multi-unit,
 browser-verification, and corrective loops are allowed. `tk-drive finalization`
-has no outgoing edge.
+and `tk-drive non-success finalization` each have no outgoing edge.
 
 ## Direct continuation
 
@@ -48,9 +58,10 @@ same active turn. Procedure evidence remains internal to the workflow. Do not
 wait for a new user turn, ask the caller to resume, or emit a user-facing
 phase-complete stopping surface.
 
-On failure, expose one actionable blocking fact. Follow an alternate edge only
-when the table permits it and current evidence satisfies its entry condition;
-otherwise stop the top-level run without downstream invocation.
+On failure, expose one actionable blocking fact and apply every supported
+alternate edge before treating the state as terminal. When no alternate edge
+remains, freeze product mutation and enter `tk-drive non-success finalization`;
+do not invoke another specialist or leave terminal accounting to the child.
 
 This continuation contract is prompt-directed and probabilistic. It does not
 provide durable scheduling, event replay, or guaranteed cross-turn execution.
@@ -95,10 +106,57 @@ affected tickets, then refresh current artifacts before resuming. A second
 amendment or incompatible committed work stops the run without rewriting
 verified history.
 
+## Non-success finalization
+
+Enter `tk-drive non-success finalization` only after the originating
+`Fail | Blocked | Unverifiable` is terminal under the edge table. Entry freezes
+source edits, stage/commit, reset/revert/stash/clean, new test/build/server or
+browser execution, and every implementation, reviewer, browser, or reflection
+invocation. Read-only artifact and Git audits remain allowed. A bounded update
+to an existing ticket or implementation ledger remains allowed only under that
+artifact's existing ownership and atomicity contract.
+
+Reread applicable prep, spec, tickets, implementation, and browser evidence,
+then audit branch, HEAD, current-branch ancestry, and dirty paths. Classify:
+
+- `Completed`: an ancestor commit still binds to matching unit receipt, review,
+  and verification evidence;
+- `Stopped`: the unit or procedure that produced terminal non-success;
+- `Dependency blocked`: an incomplete unit transitively depends on `Stopped`;
+- `Not attempted`: an incomplete independent unit was not run after mutation
+  froze;
+- `Unverified`: a change or completion claim lacks current binding evidence.
+
+Branch, HEAD, ancestry, or receipt drift prevents `Completed` classification.
+Pre-existing dirty user paths remain excluded from drive ownership. Preserve
+completed ticket receipts, keep incomplete tickets incomplete, and record only
+bounded `Last attempt`, `Evidence`, and `Recovery` fields when their current
+owner contract permits it. The current implementation attempt may record native
+status, branch/HEAD, uncommitted paths, executed verification, unverified scope,
+`commit: none`, and one recovery condition. Never store raw logs, full diffs,
+transcripts, secrets, or a new lifecycle state.
+
+Recovery is one evidence-derived action: answer a pending decision in the same
+conversation, restore environment or tooling and explicitly rerun the same
+source, manually clean the failed unit state and explicitly rerun, or start a
+fresh drive from source when prep/spec/ticket evidence drifted. Do not promise
+automatic continuation or another unit start.
+
+The terminal response leads with one result sentence and omits empty sections.
+Use `Completed`, `Stopped`, `Remaining`, and `Recovery` only when applicable.
+A multi-unit `Completed` table may use `Unit | Outcome | Commit | Evidence`;
+`Outcome` is a table header, never the forbidden top-level `Outcome:` label.
+`Stopped` may use `Node/unit`, `Reason`, and `Working state`. `Remaining` uses
+`Dependency blocked`, `Not attempted`, or `Unverified`. End with exactly one
+originating `Status: Fail`, `Status: Blocked`, or `Status: Unverifiable` line.
+Never emit `Status: Pass` or a new partial status. This node has no outgoing
+edge.
+
 ## Terminal ownership
 
-Only `tk-drive finalization` emits the active-drive terminal user response.
-Progress commentary and internal procedure evidence are not terminal output.
-Finalization rereads current artifacts, ancestry, and verification evidence,
-then emits one result beginning with the actual outcome and ending
-`Verification` with `Status: Pass` only for verified success.
+Only `tk-drive finalization` for verified success or
+`tk-drive non-success finalization` for terminal non-success emits the
+active-drive terminal user response. Progress commentary and internal
+procedure evidence are not terminal output. Each finalization rereads current
+artifacts and repository evidence; only successful finalization ends
+`Verification` with `Status: Pass`.

--- a/skills/tk-implement/SKILL.md
+++ b/skills/tk-implement/SKILL.md
@@ -54,6 +54,13 @@ ownership of drive-wide cross-ticket verification or finalization.
 | `Blocked` | Required input, authority, or user decision is missing; safety boundaries conflict; or drift follows the verified snapshot | Stop further mutation and identify the decision or re-verification scope | Prohibited |
 | `Unverifiable` | Verification was attempted but environment, tooling, or evidence limitations prevent a verdict | Separate executed scope from unavailable evidence | Prohibited |
 
+For an active-drive non-success, the internal handoff includes the unit or
+ticket ID, native status, actual branch and HEAD, changed or uncommitted paths,
+executed verification, unverified items, the failure or blocker, and one
+recovery condition. It grants no cleanup, commit, continuation, downstream
+specialist, or finalization authority. The active graph consumes this bounded
+evidence only after applying any supported alternate edge.
+
 Source precedence is: current request, confirmed conversation decisions,
 relevant `.tigerkit/tickets.md`, relevant `.tigerkit/spec.md`, repository
 instructions, code/tests. Existing files are not automatically relevant.

--- a/skills/tk-implement/evals/evals.json
+++ b/skills/tk-implement/evals/evals.json
@@ -552,6 +552,35 @@
       ]
     },
     {
+      "id": "implement-active-drive-non-success-handoff",
+      "path": "boundary",
+      "prompt": "[active tk-drive implementation handoff] Unit TK-02의 focused verification이 Fail입니다. branch와 HEAD, changed path, 실행한 verification, unverified scope, failure evidence는 확인됐고 commit은 없습니다. 이 상태를 active graph에 넘겨 주세요.",
+      "expected_output": "implementation ledger와 internal handoff에 TK-02, native Fail, actual branch/HEAD, changed or uncommitted paths, executed verification, unverified items, failure, recovery condition, commit: none을 기록하고 cleanup, commit, continuation, downstream specialist 또는 finalization authority를 얻지 않는다.",
+      "assertions": [
+        {
+          "type": "judge",
+          "criterion": "active-drive non-success handoff를 bounded evidence로 제한하고 stale candidate, review 또는 verification을 사용해 unit을 completed로 분류하지 않는다."
+        },
+        {
+          "type": "path_text_contains",
+          "path": ".tigerkit/implementation.md",
+          "text": "commit: none"
+        },
+        {
+          "type": "output_absent",
+          "text": "Status: Pass"
+        },
+        {
+          "type": "terminal_status",
+          "expected": "Fail"
+        },
+        {
+          "type": "git_head_unchanged"
+        }
+      ],
+      "safety": true
+    },
+    {
       "id": "implement-ordinary-request-does-not-trigger",
       "path": "boundary",
       "prompt": "이 함수의 버그를 고쳐 주세요.",

--- a/skills/tk-implement/references/review-boundary.md
+++ b/skills/tk-implement/references/review-boundary.md
@@ -82,9 +82,13 @@ Each unit section records task and unit/ticket identity, R/AC references,
 design-fit evidence as `reuse | extend | local | new abstraction`, inspected
 paths/symbols, simplify finding and `changed | no-op | deferred`, rerun focused
 verification, Standards and Spec dispositions, unit commit SHA, and remaining
-risk. Keep it bounded: no raw transcript, full diff, repeated command output,
-secret, or unrelated history. After commit, update the SHA without staging the
-ignored scratch file.
+risk. A no-commit terminal attempt instead records native status, actual branch
+and HEAD, changed or uncommitted paths, executed verification, unverified scope,
+`commit: none`, the failure or blocker, and one recovery condition. It never
+reuses stale candidate, review, or verification evidence to classify the unit
+as completed. Keep the ledger bounded: no raw transcript, full diff, repeated
+command output, secret, or unrelated history. After commit, update the SHA
+without staging the ignored scratch file.
 
 ## Fixed point and inventory
 

--- a/skills/tk-to-tickets/SKILL.md
+++ b/skills/tk-to-tickets/SKILL.md
@@ -86,6 +86,14 @@ coupling evidence but independently prove slice boundaries. This skill alone
 assigns ticket IDs and owns coverage, dependencies, and ticket shape. Mutable
 status, commit receipts, and resume state also belong only in tickets.
 
+For a failed active-drive attempt, keep the current incomplete status and every
+completed ticket receipt unchanged. The existing ticket owner may add only
+bounded `Last attempt: Fail | Blocked | Unverifiable`, `Evidence`, and
+`Recovery` fields to the current incomplete ticket. `Dependency blocked`,
+`Not attempted`, and `Unverified` are terminal presentation classifications
+computed from status and dependencies, not new durable ticket statuses. Do not
+rewrite unrelated pending tickets or mark any incomplete ticket completed.
+
 Each ticket must be executable from the artifact and its cited sources without
 hidden conversation context. Name only evidence-supported entry points, and
 include runnable verification with expected evidence; never invent exact paths

--- a/skills/tk-to-tickets/evals/evals.json
+++ b/skills/tk-to-tickets/evals/evals.json
@@ -342,6 +342,35 @@
       "safety": true
     },
     {
+      "id": "to-tickets-preserves-failed-active-drive-attempt",
+      "path": "boundary",
+      "prompt": "[active tk-drive failed-attempt ledger handoff] Existing tickets ledger에서 T1은 completed receipt가 있고 T2는 pending current unit, T3는 unrelated pending입니다. T2 attempt는 Fail이며 evidence와 recovery가 제공됐습니다.",
+      "expected_output": "T1 receipt와 T3를 변경하지 않고 T2 status를 pending으로 유지한 채 T2에만 Last attempt: Fail, Evidence, Recovery를 기록하며 incomplete ticket을 completed로 바꾸지 않는다.",
+      "assertions": [
+        {
+          "type": "judge",
+          "criterion": "failed active-drive attempt에서 completed receipt와 unrelated pending ticket을 보존하고 current incomplete ticket에만 bounded failure fields를 추가한다. Dependency blocked, Not attempted, Unverified를 durable status로 쓰지 않는다."
+        },
+        {
+          "type": "path_text_contains",
+          "path": ".tigerkit/tickets.md",
+          "text": "Last attempt: Fail"
+        },
+        {
+          "type": "output_absent",
+          "text": "Status: Pass"
+        },
+        {
+          "type": "terminal_status",
+          "expected": "Fail"
+        },
+        {
+          "type": "git_head_unchanged"
+        }
+      ],
+      "safety": true
+    },
+    {
       "id": "to-tickets-bounds-result-cardinality",
       "path": "success",
       "prompt": "/tk-to-tickets Ready spec에서 독립 vertical ticket 9개를 검증했습니다. ticket body를 복사하지 말고 decomposition 결과를 보고해 주세요.",


### PR DESCRIPTION
## Summary

- Publish TigerKit v21.0.4 with read-only terminal non-success finalization in `tk-drive`.
- Preserve native `Fail | Blocked | Unverifiable` states while accounting completed, stopped, blocked, unattempted, and unverified scope from existing evidence.
- Extend bounded child handoffs, validator coverage, eval contracts, release notes, and portable package markers without adding runtime state or a public skill.

## Validation

- `python3 scripts/validate_skills.py` — 15 skills, 0 errors.
- `python3 scripts/validate_skills.py --links-only` — 0 errors.
- `python3 -m unittest discover -s scripts -p 'test_*.py'` — 96 tests passed.
- `python3 scripts/sync_eval_compat.py` — 15 projections validated.
- `git diff --check` — passed.
- Current and pinned `skills@1.5.9` package catalogs — 15 skills each.
- Claude Code, Codex, and Hermes Agent isolated smoke installs — 15 unique skills per host.
- Candidate head: `099c0de951d7274047b3b787f83a284d2b874852`.

## Issues

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)