### PR TITLE
ci: auto-create verified patch tag on main

### DIFF
--- a/.github/workflows/auto-patch-tag.yml
+++ b/.github/workflows/auto-patch-tag.yml
@@ -1,0 +1,100 @@
+name: Auto patch tag
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .github/workflows/auto-patch-tag.yml
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-patch-tag-main
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create verified next patch tag
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          git fetch --force origin 'refs/tags/*:refs/tags/*'
+
+          version="$({ python3 - <<'PY'
+          import re
+          from pathlib import Path
+
+          text = Path('README.md').read_text(encoding='utf-8')
+          patterns = (
+              r'TigerKit ([0-9]+\.[0-9]+\.[0-9]+)는',
+              r'최신 immutable release는 `v([0-9]+\.[0-9]+\.[0-9]+)`',
+              r'변경되지 않는 `v([0-9]+\.[0-9]+\.[0-9]+)` snapshot',
+              r'Current release: \[`v([0-9]+\.[0-9]+\.[0-9]+)`\]',
+          )
+          versions = {
+              match.group(1)
+              for pattern in patterns
+              for match in re.finditer(pattern, text)
+          }
+          if len(versions) != 1:
+              raise SystemExit(
+                  f'expected one consistent README release version, found: {sorted(versions)}'
+              )
+          print(versions.pop())
+          PY
+          } )"
+          target_tag="v${version}"
+          head_sha="$(git rev-parse HEAD)"
+
+          if git rev-parse -q --verify "refs/tags/${target_tag}" >/dev/null; then
+            tagged_sha="$(git rev-parse "${target_tag}^{}")"
+            if [ "$tagged_sha" = "$head_sha" ]; then
+              printf '%s already tags this main commit.\n' "$target_tag"
+              exit 0
+            fi
+            printf '%s already exists at %s, not %s.\n' \
+              "$target_tag" "$tagged_sha" "$head_sha" >&2
+            exit 1
+          fi
+
+          latest_tag="$({
+            git tag --list 'v*' |
+              grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' |
+              sort -V |
+              tail -1
+          } || true)"
+
+          if [ -z "$latest_tag" ]; then
+            expected_tag='v0.0.1'
+          else
+            IFS=. read -r major minor patch <<<"${latest_tag#v}"
+            expected_tag="v${major}.${minor}.$((patch + 1))"
+          fi
+
+          if [ "$target_tag" != "$expected_tag" ]; then
+            printf 'README declares %s, but the next patch after %s is %s. No tag created.\n' \
+              "$target_tag" "${latest_tag:-<none>}" "$expected_tag" >&2
+            exit 1
+          fi
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$target_tag" "$head_sha" -m "${GITHUB_REPOSITORY} ${target_tag}"
+          git push origin "refs/tags/${target_tag}"
+
+          remote_sha="$(
+            git ls-remote --tags origin "refs/tags/${target_tag}^{}" |
+              awk 'NR == 1 { print $1 }'
+          )"
+          test "$remote_sha" = "$head_sha"
+          printf 'Created %s at %s.\n' "$target_tag" "$head_sha"


### PR DESCRIPTION
## Summary

- Add a main-push workflow that reads the repository's declared release version from README.
- Create an annotated tag only when that version is exactly the next semantic patch after the latest stable tag.
- Treat an exact existing tag as a no-op and fail closed on version drift or tag/SHA mismatch.
- Ignore workflow-only changes so installing the workflow does not create a release tag.

## Safety

- Never moves, deletes, or overwrites an existing tag.
- Never infers a version from commit count or timestamps.
- Requires all README release markers to agree.
- Verifies the remote peeled tag SHA equals the pushed main SHA.

## Validation

- YAML and embedded Bash reviewed against the current v21.0.5 README markers.
- Workflow-only merge is excluded by `paths-ignore`.

## Issues

Issues: none