### PR TITLE
fix(release): make live agent canary advisory

### DIFF
--- a/evals/release-critical.json
+++ b/evals/release-critical.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "hosts": [
-    "claude-code",
     "codex",
+    "claude-code",
     "hermes-agent"
   ],
   "runs": 2,

--- a/evals/release-critical.json
+++ b/evals/release-critical.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "hosts": [
+    "claude-code",
+    "codex",
+    "hermes-agent"
+  ],
+  "runs": 2,
+  "behavior_cases": [
+    "tk-drive:behavior:drive-live-direct-prepares-and-executes-source",
+    "tk-drive:behavior:drive-live-direct-prepared-execution",
+    "tk-drive:behavior:drive-live-direct-implementation-holdout",
+    "tk-drive:behavior:drive-keeps-grill-pending-open"
+  ],
+  "catalog_cases": [
+    "catalog:behavior:drive-vs-grill-drive",
+    "catalog:behavior:drive-vs-grill-standalone-grill",
+    "catalog:behavior:spec-vs-tickets-spec",
+    "catalog:behavior:reflect-vs-grooming-reflect",
+    "catalog:behavior:learn-vs-reflect-grooming-learn",
+    "catalog:behavior:implement-vs-drive-drive",
+    "catalog:behavior:implement-vs-drive-ordinary-request",
+    "catalog:behavior:prototype-vs-browser-browser",
+    "catalog:behavior:handoff-vs-summary-handoff",
+    "catalog:behavior:drive-vs-handoff-resume-generic",
+    "catalog:behavior:merge-conflict-vs-marker-active",
+    "catalog:behavior:merge-conflict-vs-marker-ordinary",
+    "catalog:behavior:skill-diagnose-vs-code-debugging"
+  ]
+}

--- a/scripts/run_release_gate.py
+++ b/scripts/run_release_gate.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Run TigerKit's local release gate without GitHub Actions."""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Mapping
+
+from run_skill_evals import (
+    SUPPORTED_HOSTS,
+    compare_catalog_contracts,
+    compare_eval_contracts,
+    detached_worktree,
+    git_head,
+    grade_behavior,
+    isolated_checkout,
+    load_catalog_contract,
+    load_eval_contracts,
+    resolve_ref,
+    run_adapter,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "evals" / "release-critical.json"
+
+
+def run_checked(command: list[str], *, cwd: Path) -> dict[str, object]:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return {
+        "command": shlex.join(command),
+        "passed": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "stdout_tail": completed.stdout[-2000:],
+        "stderr_tail": completed.stderr[-2000:],
+    }
+
+
+def load_manifest() -> dict[str, object]:
+    value = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("release-critical manifest must be an object")
+    hosts = value.get("hosts")
+    runs = value.get("runs")
+    behavior = value.get("behavior_cases")
+    routing = value.get("catalog_cases")
+    if hosts != list(SUPPORTED_HOSTS):
+        raise ValueError("release-critical hosts must exactly match supported hosts")
+    if isinstance(runs, bool) or not isinstance(runs, int) or runs < 2:
+        raise ValueError("release-critical runs must be an integer of at least two")
+    if not isinstance(behavior, list) or not all(isinstance(v, str) and v for v in behavior):
+        raise ValueError("release-critical behavior_cases must be a string list")
+    if not isinstance(routing, list) or not all(isinstance(v, str) and v for v in routing):
+        raise ValueError("release-critical catalog_cases must be a string list")
+    return value
+
+
+def normalized_assertions(case: Mapping[str, object]) -> list[dict[str, object]]:
+    rows = case.get("assertions", [])
+    if not isinstance(rows, list):
+        raise ValueError(f"case {case.get('id')} assertions must be a list")
+    result: list[dict[str, object]] = []
+    for raw in rows:
+        if not isinstance(raw, dict) or raw.get("type") == "judge":
+            continue
+        row = copy.deepcopy(raw)
+        if row.get("type") in {"event_order", "event_absent", "event_count"}:
+            row["hosts"] = list(SUPPORTED_HOSTS)
+        if (
+            row.get("type") == "git_commit_count_delta"
+            and "expected" not in row
+            and isinstance(row.get("count"), int)
+        ):
+            row["expected"] = row.pop("count")
+        result.append(row)
+    if not any(row.get("type") == "terminal_status" for row in result):
+        raise ValueError(f"case {case.get('id')} needs a mechanical terminal assertion")
+    return result
+
+
+def behavior_case_map(
+    contracts: Mapping[str, Mapping[str, object]],
+) -> dict[str, tuple[str, Mapping[str, object]]]:
+    result: dict[str, tuple[str, Mapping[str, object]]] = {}
+    for skill, contract in contracts.items():
+        behavior = contract["behavior"]["evals"]  # type: ignore[index]
+        for case in behavior:
+            result[f"{skill}:behavior:{case['id']}"] = (skill, case)
+    return result
+
+
+def catalog_case_map(
+    contract: Mapping[str, object] | None,
+) -> dict[str, Mapping[str, object]]:
+    if not isinstance(contract, Mapping):
+        return {}
+    rows = contract.get("cases", [])
+    if not isinstance(rows, list):
+        return {}
+    return {
+        f"catalog:behavior:{row['id']}": row
+        for row in rows
+        if isinstance(row, dict) and isinstance(row.get("id"), str)
+    }
+
+
+def run_live_gate(
+    candidate_root: Path,
+    contracts: Mapping[str, Mapping[str, object]],
+    catalog: Mapping[str, object] | None,
+    *,
+    adapter_command: str,
+    manifest: Mapping[str, object],
+) -> tuple[list[dict[str, object]], list[str], list[str]]:
+    records: list[dict[str, object]] = []
+    failures: list[str] = []
+    unavailable: list[str] = []
+    behavior = behavior_case_map(contracts)
+    routing = catalog_case_map(catalog)
+    runs = int(manifest["runs"])
+
+    for host in SUPPORTED_HOSTS:
+        for case_id in manifest["behavior_cases"]:  # type: ignore[index]
+            item = behavior.get(str(case_id))
+            if item is None:
+                failures.append(f"missing release behavior case: {case_id}")
+                continue
+            skill, case = item
+            assertions = normalized_assertions(case)
+            for run_number in range(1, runs + 1):
+                try:
+                    with isolated_checkout(candidate_root) as checkout:
+                        initial_head = git_head(checkout)
+                        adapter_result = run_adapter(
+                            adapter_command,
+                            checkout=checkout,
+                            skill=skill,
+                            prompt=str(case["prompt"]),
+                            mode="behavior",
+                            host=host,
+                        )
+                        assertion_results = grade_behavior(
+                            "",
+                            adapter_result,
+                            assertions,
+                            checkout=checkout,
+                            initial_head=initial_head,
+                            host=host,
+                        )
+                    passed = all(bool(row["passed"]) for row in assertion_results)
+                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+                    unavailable.append(f"{host} {case_id}: {exc}")
+                    records.append(
+                        {
+                            "host": host,
+                            "case": case_id,
+                            "run": run_number,
+                            "passed": False,
+                            "unavailable": str(exc),
+                        }
+                    )
+                    continue
+                records.append(
+                    {
+                        "host": host,
+                        "case": case_id,
+                        "run": run_number,
+                        "passed": passed,
+                        "terminal_status": adapter_result.get("terminal_status"),
+                        "events": adapter_result.get("events"),
+                        "assertions": assertion_results,
+                    }
+                )
+                if not passed:
+                    failures.append(f"{host} {case_id} run {run_number} failed")
+
+        for case_id in manifest["catalog_cases"]:  # type: ignore[index]
+            case = routing.get(str(case_id))
+            if case is None:
+                failures.append(f"missing release catalog case: {case_id}")
+                continue
+            for run_number in range(1, runs + 1):
+                try:
+                    with isolated_checkout(candidate_root) as checkout:
+                        adapter_result = run_adapter(
+                            adapter_command,
+                            checkout=checkout,
+                            skill=str(case["focus_skill"]),
+                            prompt=str(case["prompt"]),
+                            mode="catalog-routing",
+                            host=host,
+                        )
+                    expected = case.get("expected_selected_skill")
+                    loaded = adapter_result.get("loaded_skills")
+                    passed = (
+                        adapter_result.get("selected_skill") == expected
+                        and (
+                            expected is None
+                            or isinstance(loaded, list)
+                            and expected in loaded
+                        )
+                    )
+                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+                    unavailable.append(f"{host} {case_id}: {exc}")
+                    records.append(
+                        {
+                            "host": host,
+                            "case": case_id,
+                            "run": run_number,
+                            "passed": False,
+                            "unavailable": str(exc),
+                        }
+                    )
+                    continue
+                records.append(
+                    {
+                        "host": host,
+                        "case": case_id,
+                        "run": run_number,
+                        "passed": passed,
+                        "expected_selected_skill": expected,
+                        "actual_selected_skill": adapter_result.get("selected_skill"),
+                        "loaded_skills": loaded,
+                    }
+                )
+                if not passed:
+                    failures.append(f"{host} {case_id} run {run_number} failed")
+
+    return records, sorted(set(failures)), sorted(set(unavailable))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--candidate", default="HEAD")
+    parser.add_argument("--adapter-command", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output = Path(args.output).resolve()
+    if output == ROOT or ROOT in output.parents:
+        raise SystemExit("--output must be outside the repository")
+    output.mkdir(parents=True, exist_ok=True)
+
+    manifest = load_manifest()
+    baseline_sha = resolve_ref(args.baseline)
+    candidate_sha = resolve_ref(args.candidate)
+    static_records: list[dict[str, object]] = []
+    contract_errors: list[str] = []
+
+    with detached_worktree(args.baseline) as baseline_root, detached_worktree(
+        args.candidate
+    ) as candidate_root:
+        baseline_contracts = load_eval_contracts(baseline_root, None)
+        candidate_contracts = load_eval_contracts(candidate_root, None)
+        baseline_catalog = load_catalog_contract(baseline_root)
+        candidate_catalog = load_catalog_contract(candidate_root)
+        contract_errors.extend(compare_eval_contracts(baseline_contracts, candidate_contracts))
+        contract_errors.extend(compare_catalog_contracts(baseline_catalog, candidate_catalog))
+
+        commands = [
+            ["python3", "scripts/validate_skills.py"],
+            ["python3", "scripts/validate_skills.py", "--links-only"],
+            ["python3", "-m", "unittest", "discover", "-s", "scripts", "-p", "test_*.py"],
+            ["python3", "scripts/sync_eval_compat.py"],
+            ["git", "diff", "--exit-code"],
+            ["npx", "--yes", "skills@1.5.9", "add", ".", "--list"],
+            ["npx", "--yes", "skills", "add", ".", "--list"],
+            ["git", "diff", "--check"],
+        ]
+        for command in commands:
+            static_records.append(run_checked(command, cwd=candidate_root))
+
+        live_records, live_failures, unavailable = run_live_gate(
+            candidate_root,
+            candidate_contracts,
+            candidate_catalog,
+            adapter_command=args.adapter_command,
+            manifest=manifest,
+        )
+
+    static_failures = [
+        str(row["command"]) for row in static_records if not bool(row["passed"])
+    ]
+    reasons = sorted(set(contract_errors + static_failures + live_failures))
+    status = "Fail" if reasons else "Unverifiable" if unavailable else "Pass"
+    result = {
+        "status": status,
+        "baseline": baseline_sha,
+        "candidate": candidate_sha,
+        "manifest": manifest,
+        "contract_errors": contract_errors,
+        "static": static_records,
+        "live": live_records,
+        "reasons": reasons,
+        "unavailable": unavailable,
+    }
+    (output / "release-gate.json").write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if status == "Pass" else 1 if status == "Fail" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_release_gate.py
+++ b/scripts/run_release_gate.py
@@ -26,6 +26,7 @@ from run_skill_evals import (
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "evals" / "release-critical.json"
+HOST_ORDER = ("codex", "claude-code", "hermes-agent")
 
 
 def run_checked(command: list[str], *, cwd: Path) -> dict[str, object]:
@@ -53,8 +54,12 @@ def load_manifest() -> dict[str, object]:
     runs = value.get("runs")
     behavior = value.get("behavior_cases")
     routing = value.get("catalog_cases")
-    if hosts != list(SUPPORTED_HOSTS):
-        raise ValueError("release-critical hosts must exactly match supported hosts")
+    if hosts != list(HOST_ORDER):
+        raise ValueError(
+            "release-critical hosts must be ordered codex, claude-code, hermes-agent"
+        )
+    if not set(HOST_ORDER).issubset(set(SUPPORTED_HOSTS)):
+        raise ValueError("release-critical host order contains an unsupported host")
     if isinstance(runs, bool) or not isinstance(runs, int) or runs < 2:
         raise ValueError("release-critical runs must be an integer of at least two")
     if not isinstance(behavior, list) or not all(isinstance(v, str) and v for v in behavior):
@@ -74,7 +79,7 @@ def normalized_assertions(case: Mapping[str, object]) -> list[dict[str, object]]
             continue
         row = copy.deepcopy(raw)
         if row.get("type") in {"event_order", "event_absent", "event_count"}:
-            row["hosts"] = list(SUPPORTED_HOSTS)
+            row["hosts"] = list(HOST_ORDER)
         if (
             row.get("type") == "git_commit_count_delta"
             and "expected" not in row
@@ -113,136 +118,194 @@ def catalog_case_map(
     }
 
 
-def run_live_gate(
+def validate_manifest_cases(
+    contracts: Mapping[str, Mapping[str, object]],
+    catalog: Mapping[str, object] | None,
+    manifest: Mapping[str, object],
+) -> list[str]:
+    behavior = behavior_case_map(contracts)
+    routing = catalog_case_map(catalog)
+    errors = [
+        f"missing release behavior case: {case_id}"
+        for case_id in manifest["behavior_cases"]  # type: ignore[index]
+        if str(case_id) not in behavior
+    ]
+    errors.extend(
+        f"missing release catalog case: {case_id}"
+        for case_id in manifest["catalog_cases"]  # type: ignore[index]
+        if str(case_id) not in routing
+    )
+    return errors
+
+
+def run_one_host(
+    host: str,
     candidate_root: Path,
     contracts: Mapping[str, Mapping[str, object]],
     catalog: Mapping[str, object] | None,
     *,
     adapter_command: str,
     manifest: Mapping[str, object],
-) -> tuple[list[dict[str, object]], list[str], list[str]]:
+) -> tuple[list[dict[str, object]], list[str], str | None]:
     records: list[dict[str, object]] = []
     failures: list[str] = []
-    unavailable: list[str] = []
     behavior = behavior_case_map(contracts)
     routing = catalog_case_map(catalog)
     runs = int(manifest["runs"])
 
-    for host in SUPPORTED_HOSTS:
-        for case_id in manifest["behavior_cases"]:  # type: ignore[index]
-            item = behavior.get(str(case_id))
-            if item is None:
-                failures.append(f"missing release behavior case: {case_id}")
-                continue
-            skill, case = item
-            assertions = normalized_assertions(case)
-            for run_number in range(1, runs + 1):
-                try:
-                    with isolated_checkout(candidate_root) as checkout:
-                        initial_head = git_head(checkout)
-                        adapter_result = run_adapter(
-                            adapter_command,
-                            checkout=checkout,
-                            skill=skill,
-                            prompt=str(case["prompt"]),
-                            mode="behavior",
-                            host=host,
-                        )
-                        assertion_results = grade_behavior(
-                            "",
-                            adapter_result,
-                            assertions,
-                            checkout=checkout,
-                            initial_head=initial_head,
-                            host=host,
-                        )
-                    passed = all(bool(row["passed"]) for row in assertion_results)
-                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
-                    unavailable.append(f"{host} {case_id}: {exc}")
-                    records.append(
-                        {
-                            "host": host,
-                            "case": case_id,
-                            "run": run_number,
-                            "passed": False,
-                            "unavailable": str(exc),
-                        }
+    for case_id in manifest["behavior_cases"]:  # type: ignore[index]
+        skill, case = behavior[str(case_id)]
+        assertions = normalized_assertions(case)
+        for run_number in range(1, runs + 1):
+            try:
+                with isolated_checkout(candidate_root) as checkout:
+                    initial_head = git_head(checkout)
+                    adapter_result = run_adapter(
+                        adapter_command,
+                        checkout=checkout,
+                        skill=skill,
+                        prompt=str(case["prompt"]),
+                        mode="behavior",
+                        host=host,
                     )
-                    continue
+                    assertion_results = grade_behavior(
+                        "",
+                        adapter_result,
+                        assertions,
+                        checkout=checkout,
+                        initial_head=initial_head,
+                        host=host,
+                    )
+            except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
                 records.append(
                     {
                         "host": host,
                         "case": case_id,
                         "run": run_number,
-                        "passed": passed,
-                        "terminal_status": adapter_result.get("terminal_status"),
-                        "events": adapter_result.get("events"),
-                        "assertions": assertion_results,
+                        "passed": False,
+                        "unavailable": str(exc),
                     }
                 )
-                if not passed:
-                    failures.append(f"{host} {case_id} run {run_number} failed")
+                return records, failures, str(exc)
+            passed = all(bool(row["passed"]) for row in assertion_results)
+            records.append(
+                {
+                    "host": host,
+                    "case": case_id,
+                    "run": run_number,
+                    "passed": passed,
+                    "terminal_status": adapter_result.get("terminal_status"),
+                    "events": adapter_result.get("events"),
+                    "assertions": assertion_results,
+                }
+            )
+            if not passed:
+                failures.append(f"{host} {case_id} run {run_number} failed")
 
-        for case_id in manifest["catalog_cases"]:  # type: ignore[index]
-            case = routing.get(str(case_id))
-            if case is None:
-                failures.append(f"missing release catalog case: {case_id}")
-                continue
-            for run_number in range(1, runs + 1):
-                try:
-                    with isolated_checkout(candidate_root) as checkout:
-                        adapter_result = run_adapter(
-                            adapter_command,
-                            checkout=checkout,
-                            skill=str(case["focus_skill"]),
-                            prompt=str(case["prompt"]),
-                            mode="catalog-routing",
-                            host=host,
-                        )
-                    expected = case.get("expected_selected_skill")
-                    loaded = adapter_result.get("loaded_skills")
-                    passed = (
-                        adapter_result.get("selected_skill") == expected
-                        and (
-                            expected is None
-                            or isinstance(loaded, list)
-                            and expected in loaded
-                        )
+    for case_id in manifest["catalog_cases"]:  # type: ignore[index]
+        case = routing[str(case_id)]
+        for run_number in range(1, runs + 1):
+            try:
+                with isolated_checkout(candidate_root) as checkout:
+                    adapter_result = run_adapter(
+                        adapter_command,
+                        checkout=checkout,
+                        skill=str(case["focus_skill"]),
+                        prompt=str(case["prompt"]),
+                        mode="catalog-routing",
+                        host=host,
                     )
-                except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
-                    unavailable.append(f"{host} {case_id}: {exc}")
-                    records.append(
-                        {
-                            "host": host,
-                            "case": case_id,
-                            "run": run_number,
-                            "passed": False,
-                            "unavailable": str(exc),
-                        }
-                    )
-                    continue
+            except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
                 records.append(
                     {
                         "host": host,
                         "case": case_id,
                         "run": run_number,
-                        "passed": passed,
-                        "expected_selected_skill": expected,
-                        "actual_selected_skill": adapter_result.get("selected_skill"),
-                        "loaded_skills": loaded,
+                        "passed": False,
+                        "unavailable": str(exc),
                     }
                 )
-                if not passed:
-                    failures.append(f"{host} {case_id} run {run_number} failed")
+                return records, failures, str(exc)
+            expected = case.get("expected_selected_skill")
+            loaded = adapter_result.get("loaded_skills")
+            passed = (
+                adapter_result.get("selected_skill") == expected
+                and (expected is None or isinstance(loaded, list) and expected in loaded)
+            )
+            records.append(
+                {
+                    "host": host,
+                    "case": case_id,
+                    "run": run_number,
+                    "passed": passed,
+                    "expected_selected_skill": expected,
+                    "actual_selected_skill": adapter_result.get("selected_skill"),
+                    "loaded_skills": loaded,
+                }
+            )
+            if not passed:
+                failures.append(f"{host} {case_id} run {run_number} failed")
 
-    return records, sorted(set(failures)), sorted(set(unavailable))
+    return records, sorted(set(failures)), None
+
+
+def run_live_gate(
+    candidate_root: Path,
+    contracts: Mapping[str, Mapping[str, object]],
+    catalog: Mapping[str, object] | None,
+    *,
+    adapter_command: str | None,
+    manifest: Mapping[str, object],
+) -> tuple[list[dict[str, object]], list[dict[str, object]], str | None]:
+    records: list[dict[str, object]] = []
+    host_results: list[dict[str, object]] = []
+    if not adapter_command:
+        return (
+            records,
+            [
+                {"host": host, "status": "not-run", "reason": "adapter command unavailable"}
+                for host in HOST_ORDER
+            ],
+            None,
+        )
+
+    selected_host: str | None = None
+    for index, host in enumerate(HOST_ORDER):
+        host_records, failures, unavailable = run_one_host(
+            host,
+            candidate_root,
+            contracts,
+            catalog,
+            adapter_command=adapter_command,
+            manifest=manifest,
+        )
+        records.extend(host_records)
+        if unavailable is not None:
+            host_results.append(
+                {"host": host, "status": "unavailable", "reason": unavailable}
+            )
+            continue
+        if failures:
+            host_results.append(
+                {"host": host, "status": "failed", "failures": failures}
+            )
+            continue
+        selected_host = host
+        host_results.append({"host": host, "status": "passed"})
+        for remaining in HOST_ORDER[index + 1 :]:
+            host_results.append(
+                {"host": remaining, "status": "not-run", "reason": f"{host} already passed"}
+            )
+        break
+
+    return records, host_results, selected_host
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--baseline", required=True)
     parser.add_argument("--candidate", default="HEAD")
-    parser.add_argument("--adapter-command", required=True)
+    parser.add_argument("--adapter-command")
     parser.add_argument("--output", required=True)
     return parser.parse_args()
 
@@ -269,6 +332,9 @@ def main() -> int:
         candidate_catalog = load_catalog_contract(candidate_root)
         contract_errors.extend(compare_eval_contracts(baseline_contracts, candidate_contracts))
         contract_errors.extend(compare_catalog_contracts(baseline_catalog, candidate_catalog))
+        contract_errors.extend(
+            validate_manifest_cases(candidate_contracts, candidate_catalog, manifest)
+        )
 
         commands = [
             ["python3", "scripts/validate_skills.py"],
@@ -283,7 +349,7 @@ def main() -> int:
         for command in commands:
             static_records.append(run_checked(command, cwd=candidate_root))
 
-        live_records, live_failures, unavailable = run_live_gate(
+        live_records, host_results, selected_host = run_live_gate(
             candidate_root,
             candidate_contracts,
             candidate_catalog,
@@ -294,25 +360,32 @@ def main() -> int:
     static_failures = [
         str(row["command"]) for row in static_records if not bool(row["passed"])
     ]
-    reasons = sorted(set(contract_errors + static_failures + live_failures))
-    status = "Fail" if reasons else "Unverifiable" if unavailable else "Pass"
+    blocking_reasons = sorted(set(contract_errors + static_failures))
+    quality_status = "Pass" if selected_host else "Advisory"
+    status = "Fail" if blocking_reasons else "Pass"
     result = {
         "status": status,
+        "release_blocked": bool(blocking_reasons),
         "baseline": baseline_sha,
         "candidate": candidate_sha,
         "manifest": manifest,
         "contract_errors": contract_errors,
         "static": static_records,
-        "live": live_records,
-        "reasons": reasons,
-        "unavailable": unavailable,
+        "blocking_reasons": blocking_reasons,
+        "quality": {
+            "status": quality_status,
+            "host_order": list(HOST_ORDER),
+            "selected_host": selected_host,
+            "hosts": host_results,
+            "records": live_records,
+        },
     }
     (output / "release-gate.json").write_text(
         json.dumps(result, ensure_ascii=False, indent=2) + "\n",
         encoding="utf-8",
     )
     print(json.dumps(result, ensure_ascii=False, indent=2))
-    return 0 if status == "Pass" else 1 if status == "Fail" else 2
+    return 0 if status == "Pass" else 1
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_release_gate.py
+++ b/scripts/test_run_release_gate.py
@@ -14,7 +14,11 @@ from run_skill_evals import load_catalog_contract, load_eval_contracts
 class ReleaseGateContractTest(unittest.TestCase):
     def test_manifest_is_closed_and_references_existing_cases(self) -> None:
         manifest = run_release_gate.load_manifest()
-        self.assertEqual(manifest["hosts"], list(run_release_gate.SUPPORTED_HOSTS))
+        self.assertEqual(manifest["hosts"], list(run_release_gate.HOST_ORDER))
+        self.assertEqual(
+            run_release_gate.HOST_ORDER,
+            ("codex", "claude-code", "hermes-agent"),
+        )
         self.assertGreaterEqual(manifest["runs"], 2)
 
         contracts = load_eval_contracts(run_release_gate.ROOT, None)
@@ -24,15 +28,23 @@ class ReleaseGateContractTest(unittest.TestCase):
         )
         self.assertTrue(set(manifest["behavior_cases"]).issubset(behavior))
         self.assertTrue(set(manifest["catalog_cases"]).issubset(catalog))
+        self.assertEqual(
+            run_release_gate.validate_manifest_cases(
+                contracts,
+                load_catalog_contract(run_release_gate.ROOT),
+                manifest,
+            ),
+            [],
+        )
 
-    def test_manifest_rejects_reduced_host_or_run_matrix(self) -> None:
+    def test_manifest_rejects_wrong_host_order_or_reduced_runs(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "release-critical.json"
             path.write_text(
                 json.dumps(
                     {
                         "version": 1,
-                        "hosts": ["codex"],
+                        "hosts": ["claude-code", "codex", "hermes-agent"],
                         "runs": 1,
                         "behavior_cases": ["x"],
                         "catalog_cases": ["y"],
@@ -41,7 +53,7 @@ class ReleaseGateContractTest(unittest.TestCase):
                 encoding="utf-8",
             )
             with patch.object(run_release_gate, "MANIFEST", path):
-                with self.assertRaisesRegex(ValueError, "hosts"):
+                with self.assertRaisesRegex(ValueError, "ordered"):
                     run_release_gate.load_manifest()
 
     def test_normalized_assertions_are_mechanical_and_host_neutral(self) -> None:
@@ -61,12 +73,11 @@ class ReleaseGateContractTest(unittest.TestCase):
                 ],
             }
         )
-        self.assertEqual([row["type"] for row in rows], [
-            "event_order",
-            "git_commit_count_delta",
-            "terminal_status",
-        ])
-        self.assertEqual(rows[0]["hosts"], list(run_release_gate.SUPPORTED_HOSTS))
+        self.assertEqual(
+            [row["type"] for row in rows],
+            ["event_order", "git_commit_count_delta", "terminal_status"],
+        )
+        self.assertEqual(rows[0]["hosts"], list(run_release_gate.HOST_ORDER))
         self.assertEqual(rows[1]["expected"], 1)
         self.assertNotIn("count", rows[1])
 
@@ -75,6 +86,65 @@ class ReleaseGateContractTest(unittest.TestCase):
             run_release_gate.normalized_assertions(
                 {"id": "bad", "assertions": [{"type": "path_exists", "path": "x"}]}
             )
+
+    def test_live_gate_without_adapter_is_advisory_not_blocking(self) -> None:
+        records, hosts, selected = run_release_gate.run_live_gate(
+            Path("."),
+            {},
+            None,
+            adapter_command=None,
+            manifest={"runs": 2, "behavior_cases": [], "catalog_cases": []},
+        )
+        self.assertEqual(records, [])
+        self.assertIsNone(selected)
+        self.assertEqual([row["host"] for row in hosts], list(run_release_gate.HOST_ORDER))
+        self.assertTrue(all(row["status"] == "not-run" for row in hosts))
+
+    def test_live_gate_uses_ordered_fallback_and_stops_after_first_pass(self) -> None:
+        outcomes = {
+            "codex": ([], [], "codex unavailable"),
+            "claude-code": ([{"host": "claude-code"}], [], None),
+        }
+
+        def fake_run_one_host(host: str, *args: object, **kwargs: object):
+            return outcomes[host]
+
+        with patch.object(run_release_gate, "run_one_host", side_effect=fake_run_one_host) as run:
+            records, hosts, selected = run_release_gate.run_live_gate(
+                Path("."),
+                {},
+                None,
+                adapter_command="adapter",
+                manifest={"runs": 2, "behavior_cases": [], "catalog_cases": []},
+            )
+
+        self.assertEqual(selected, "claude-code")
+        self.assertEqual([call.args[0] for call in run.call_args_list], ["codex", "claude-code"])
+        self.assertEqual(records, [{"host": "claude-code"}])
+        self.assertEqual(
+            [(row["host"], row["status"]) for row in hosts],
+            [
+                ("codex", "unavailable"),
+                ("claude-code", "passed"),
+                ("hermes-agent", "not-run"),
+            ],
+        )
+
+    def test_live_gate_all_failed_remains_advisory(self) -> None:
+        def fake_run_one_host(host: str, *args: object, **kwargs: object):
+            return [], [f"{host} failed"], None
+
+        with patch.object(run_release_gate, "run_one_host", side_effect=fake_run_one_host):
+            _, hosts, selected = run_release_gate.run_live_gate(
+                Path("."),
+                {},
+                None,
+                adapter_command="adapter",
+                manifest={"runs": 2, "behavior_cases": [], "catalog_cases": []},
+            )
+
+        self.assertIsNone(selected)
+        self.assertTrue(all(row["status"] == "failed" for row in hosts))
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_release_gate.py
+++ b/scripts/test_run_release_gate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import run_release_gate
+from run_skill_evals import load_catalog_contract, load_eval_contracts
+
+
+class ReleaseGateContractTest(unittest.TestCase):
+    def test_manifest_is_closed_and_references_existing_cases(self) -> None:
+        manifest = run_release_gate.load_manifest()
+        self.assertEqual(manifest["hosts"], list(run_release_gate.SUPPORTED_HOSTS))
+        self.assertGreaterEqual(manifest["runs"], 2)
+
+        contracts = load_eval_contracts(run_release_gate.ROOT, None)
+        behavior = run_release_gate.behavior_case_map(contracts)
+        catalog = run_release_gate.catalog_case_map(
+            load_catalog_contract(run_release_gate.ROOT)
+        )
+        self.assertTrue(set(manifest["behavior_cases"]).issubset(behavior))
+        self.assertTrue(set(manifest["catalog_cases"]).issubset(catalog))
+
+    def test_manifest_rejects_reduced_host_or_run_matrix(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "release-critical.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "hosts": ["codex"],
+                        "runs": 1,
+                        "behavior_cases": ["x"],
+                        "catalog_cases": ["y"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with patch.object(run_release_gate, "MANIFEST", path):
+                with self.assertRaisesRegex(ValueError, "hosts"):
+                    run_release_gate.load_manifest()
+
+    def test_normalized_assertions_are_mechanical_and_host_neutral(self) -> None:
+        rows = run_release_gate.normalized_assertions(
+            {
+                "id": "example",
+                "assertions": [
+                    {"type": "judge", "criterion": "subjective"},
+                    {
+                        "type": "event_order",
+                        "hosts": ["codex"],
+                        "before": {"type": "phase_invocation", "phase": "a"},
+                        "after": {"type": "phase_invocation", "phase": "b"},
+                    },
+                    {"type": "git_commit_count_delta", "count": 1},
+                    {"type": "terminal_status", "expected": "Pass"},
+                ],
+            }
+        )
+        self.assertEqual([row["type"] for row in rows], [
+            "event_order",
+            "git_commit_count_delta",
+            "terminal_status",
+        ])
+        self.assertEqual(rows[0]["hosts"], list(run_release_gate.SUPPORTED_HOSTS))
+        self.assertEqual(rows[1]["expected"], 1)
+        self.assertNotIn("count", rows[1])
+
+    def test_normalized_assertions_require_terminal_verdict(self) -> None:
+        with self.assertRaisesRegex(ValueError, "mechanical terminal"):
+            run_release_gate.normalized_assertions(
+                {"id": "bad", "assertions": [{"type": "path_exists", "path": "x"}]}
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/tk-ask-repo/SKILL.md
+++ b/skills/tk-ask-repo/SKILL.md
@@ -92,16 +92,15 @@ the next owner, or one recovery action only when it changes what the user can do
 
 ### 🔴 HARD GATE · terminal user summary
 
-Keep progress and the terminal user response separate. Begin directly with `Answer`.
-Do not emit a ceremonial preamble, separator, `Outcome:`, receipt heading,
-duplicated status, or internal handoff fields. This skill is read-only and
-creates no ledger.
+Treat progress commentary, internal handoff envelopes, and the terminal user response as distinct surfaces. Begin every terminal user-facing response directly with the skill's canonical result heading or, when its result schema owns no heading, its canonical result sentence. Do not emit a standalone separator, ceremonial preamble, or progress recap before that opening. Do not emit a terminal user-summary opening between a successful phase receipt and the next active-drive phase invocation.
+
+Do not render a receipt heading, `Outcome:` label, or terminal provenance/status block in the user summary. When the host or skill requires a terminal status, emit the single exact `Status: <token>` line in the owning result section instead of a bottom metadata block. Expose a path, ID, commit, or recovery detail only when it changes user action or the skill's canonical result schema requires it. Keep phase receipts as internal handoff envelopes: when an active parent requires phase, status, IDs, `Return to`, `Success state`, or `Outstanding transition`, return them only to that parent workflow and never echo them in the terminal user summary.
+
+Persist provenance only in an artifact or ledger the skill already owns. A skill without such an owner must not create one solely to store a receipt, and a read-only skill remains read-only. Never require a shared runtime reference outside this skill.
 
 ### 🔴 HARD GATE · response language
 
-Use the latest explicit user language, otherwise the current message's language.
-Preserve canonical headings, statuses, paths, commands, code, and exact source
-literals.
+Before any user-facing progress, question, or summary, resolve the response language from the latest explicit user language instruction; otherwise use the current user message's language. Write every free-form user-facing sentence and every prose result value in that resolved language, and do not switch to English because sources, skill bodies, tools, or code are English. Keep canonical headings, status tokens, IDs, commands, paths, code, and exact quoted or source literals byte-stable; explain them in the resolved language around the preserved token. Before returning, scan all free-form user-facing prose and rewrite any sentence that drifts from the resolved language.
 
 ## User decision questions
 

--- a/skills/tk-ask-repo/SKILL.md
+++ b/skills/tk-ask-repo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-ask-repo
-description: "[user] Answer an inbound question about this repository with source-located evidence — where a value comes from, how a flow works, whether something exists, what a change breaks, or which layer owns a problem. Use when a question arrives from outside the codebase and answering it requires investigation. Do not use to implement, to close decisions, or to estimate effort."
+description: "[user] Answer an inbound question about this repository with source-located evidence: origin, flow, existence, impact, or ownership. Use when an outside question requires code investigation. Do not implement, close decisions, reproduce runtime behavior, or estimate effort."
 disable-model-invocation: true
 argument-hint: "<the inbound question, pasted verbatim>"
 metadata:
@@ -12,146 +12,103 @@ metadata:
 
 # Ask Repo
 
-Read-only investigation desk for questions that arrive from outside the
-codebase. Classify the question, apply the matching traversal, enforce one
-evidence contract, and hand off anything this skill does not own.
+Read-only investigation for questions arriving from outside the codebase. Never
+edit source, artifacts, tickets, or Git history, and never invoke a sibling
+skill. When the answer requires a decision or implementation, name the owner
+and stop.
 
-Never edit source, spec, tickets, or commits. Never invoke a sibling phase
-owner. When the answer requires a user decision, name the decision and stop.
-When the answer is settled and an artifact is wanted, name the next owner.
+## Evidence contract
 
-## Contract
-
-**Every claim carries `path:line`, or is marked `unavailable` with the
-reason.** An unsourced statement about repository state is not an answer.
-
-**A declaration is not an origin.** A type, schema, column, or interface says a
-value exists; it does not say what the value means or how it is produced.
-Descend to the expression that assigns it.
-
-**Preserve the asker's wording.** Quote the reported symptom, label, or term
-verbatim before normalizing it. The exact string is usually the only reliable
-search anchor, and rewording it loses the anchor.
-
-**Never report an unverified state as absent.** "Not found by my search" and
-"does not exist" are different claims. Report the first; earn the second.
-
-**Sweep before reporting** (families A, D, E). A fix list without an explicit
-`Must not change` section is invalid — state `none found` rather than omitting
-it.
+- Every repository-state claim cites `path:line`, or says `unavailable` with a
+  reason.
+- Preserve the asker's exact symptom, label, or identifier as the first search
+  anchor.
+- A declaration proves shape, not origin. Trace a value to the assignment,
+  stored input, literal, or external boundary that produces it.
+- "Not found" is not "absent". Search current base and relevant in-flight work
+  before concluding absence.
+- For value, impact, and attribution questions, classify consumers as
+  `must change | must not change | unclear`. `Must not change` is required and
+  says `none found` when empty.
 
 ## Workflow
 
-1. `classify`: assign the question to A/B/C/D/E below. Mixed questions
-   decompose; answer each part and say which is blocking. Out of scope
-   (implementation, decision, effort estimate, general knowledge) → name the
-   right owner and stop.
-2. `anchor`: recover a concrete starting point from the asker's own words — a
-   visible string, identifier, route, endpoint, or symbol. No anchor found →
-   report the searches attempted as `Unverifiable`; do not guess a synonym and
-   proceed as if it matched.
-3. `traverse`: run the family's traversal below. Each hop records `path:line`.
-4. `sweep` (A, D, E): find every consumer of the value or symbol across all
-   surfaces — other screens, notifications, exports, reports, jobs, tests.
-   Classify each `must change | must not change | unclear`. Never silently
-   include or exclude.
-5. `attribute` (A, E): decide ownership from what the transport already
-   carries.
-   - correct value **already present** in the response or payload → consuming
-     side only; no producer change
-   - correct value **absent**, or the assignment itself is wrong → producer
-     change; name the type and the field
-   - both → split, state which blocks the other
-6. `verify`: before reporting, record the refs and anchor/query variants
-   searched, verify any matching semantics used for scope, and confirm every
-   traversal hop is cited. For A/D/E, also record sweep exclusions and any
-   dynamic-dispatch coverage.
-7. `report`: emit the output contract. Do not propose a diff.
+1. **Classify** the question:
+   `value | structure | existence | impact | attribution`. Split mixed asks and
+   identify the blocking part.
+2. **Anchor** on the asker's visible string, identifier, route, endpoint, or
+   symbol. If no concrete anchor survives search, report the attempted queries
+   and stop `Unverifiable`.
+3. **Traverse** with the matching path below, recording `path:line` at each hop.
+4. **Sweep** all relevant readers/writers for value, impact, and attribution;
+   verify the search semantics used for any count that determines scope.
+5. **Attribute** from evidence:
+   - correct value already exists in the payload → consuming side;
+   - correct value is absent or assigned incorrectly → producer and exact field;
+   - both → split responsibility and say which blocks the other.
+6. **Verify** current ref, searched variants, dynamic-dispatch gaps, exclusions,
+   and every cited hop before reporting.
 
-### Family traversals
+## Traversals
 
-**A · Value** — anchor (visible string) → bound identifier (column id, key,
-prop) → the expression producing it on the consuming side → transport field →
-declaring type → **assignment site**. At the assignment site, read siblings and
-comments: when an adjacent field on the same record holds the intended value,
-that sibling is the likely answer, and its comment is often the only written
-record of the distinction. Recurse when the assignment reads another computed
-value; stop at a literal, a stored column, or an external input.
+- **Value**: visible string → bound key/prop/column → consuming expression →
+  transport field → declaring type → assignment site. Read sibling assignments
+  and comments before deciding meaning.
+- **Structure**: entry point → ordered boundaries such as
+  view → transport → producer → store/external. Mark dynamic dispatch.
+- **Existence**: current base ref → open/unmerged work → environment state.
+  Distinguish `absent | unreleased here | present but empty/placeholder |
+  present and live`. Trace the introducing change for "since when".
+- **Impact**: symbol/field/pattern → all readers and writers → classify each
+  consumer and state what the search excluded.
+- **Attribution**: finish the consuming-side trace before blaming the producer.
+  Check transforms, permissions, feature gates, conditional rendering, and
+  same-path environment differences.
 
-**B · Structure** — anchor (entry point) → each hop in order, naming the
-boundary crossed (view→transport, transport→producer, producer→store,
-producer→external). Report the path, not a narrative. Mark hops that are
-dynamically dispatched.
+## Failure boundaries
 
-**C · Existence** — search the *current* base ref directly, not a local checkout
-that may lag. Then search in-flight work (open changesets, unmerged branches)
-before concluding absence. Distinguish four states, which look alike and are
-not: absent · present but unreleased to this environment · present but
-returning empty or placeholder data · present and live. For "since when", trace
-the introducing change and quote it.
+| Condition | Result |
+| --- | --- |
+| anchor missing after exact and component searches | `Unverifiable` with queries run |
+| required source unreadable | cite the gap; do not infer across it |
+| two supported answers remain | `Blocked` with both and the decision owner |
+| unclear consumer remains | list it; never silently include or exclude |
+| premise contradicts current code | report the contradiction, not the premise |
+| request is implementation, decision, runtime reproduction, estimate, or general knowledge | name the correct owner and stop |
 
-**D · Impact** — anchor (symbol, field, or pattern) → all readers and writers →
-classify as in `sweep`. Count with a tool whose matching semantics you have
-verified on this host; a count that decides scope must not come from a pattern
-you have not sanity-checked. State what the count excludes.
+## Result
 
-**E · Attribution** — trace the consuming side to its end *before* attributing
-to the producer; an intermediate transform on the consuming side is the most
-common false attribution. For environment-dependent symptoms, compare the
-same code path across environments before treating it as a code defect. For
-"why is this not visible", check permission, feature gating, and conditional
-rendering before concluding the element is missing.
+Lead with `Answer`. Use one to three short paragraphs for one result, compact
+bullets or one family-specific table for two to seven, and the top five to seven
+plus owning evidence paths for larger results.
 
-## Failure paths
+Include only relevant non-empty sections:
+`Evidence | Origin | Sibling fields | Path | State | Attribution |
+Must change | Must not change | Remaining concerns`.
 
-| Trigger | Action | Still unresolved |
-|---|---|---|
-| anchor string not found | try its parts, message/i18n catalogs, and the identifier the asker quoted | `Unverifiable` listing the searches run |
-| source unreadable | record path + reason as `unavailable` | answer only what readable sources prove; do not infer across the gap |
-| two candidate answers, both defensible | present both with evidence and stop | `Blocked` — one decision, named owner |
-| sweep finds an unclear consumer | list under Remaining concerns | never silently include or exclude |
-| question is really a decision, a build request, or an estimate | name the owner and stop | do not partially perform it |
-| asker's premise contradicts the code | report the contradiction; do not answer the premise as stated | `Blocked` |
-
-## Output contract
-
-Lead with `Answer`. For one result, use one to three short paragraphs. For two to seven results, use compact bullets or one question-family table. For eight or more, show the top five to seven and cite the evidence paths that own the remainder; never invent an artifact. Add only the non-empty evidence
-sections needed for the question family: `Evidence`, `Origin`, `Sibling
-fields`, `Path`, `State`, `Attribution`, `Must change`, `Must not change`, and
-`Remaining concerns`. Evidence cites `path:line`; unavailable sources include
-the reason. For A/D/E, `Must not change` is required and says `none found` when
-empty.
-
-For multiple meaningful fields, consumers, or candidates, use one compact table with question-family columns. Use a sentence when only one user-relevant row exists; rows never represent files, commands, or raw evidence. These are
-budgets, not quotas.
-
-Do not echo the inbound question, repeat evidence across sections, or append a
-status/provenance block. State `Blocked | Unverifiable`, the next owner, or a
-recovery action only when it changes what the user can do next. This skill is
-read-only and creates no ledger solely to retain answer metadata.
+Do not echo the inbound question, repeat evidence, propose a diff, invent an
+artifact, or append a receipt/provenance block. State `Blocked | Unverifiable`,
+the next owner, or one recovery action only when it changes what the user can do.
 
 ### 🔴 HARD GATE · terminal user summary
 
-Treat progress commentary, internal handoff envelopes, and the terminal user response as distinct surfaces. Begin every terminal user-facing response directly with the skill's canonical result heading or, when its result schema owns no heading, its canonical result sentence. Do not emit a standalone separator, ceremonial preamble, or progress recap before that opening. Do not emit a terminal user-summary opening between a successful phase receipt and the next active-drive phase invocation.
-
-Do not render a receipt heading, `Outcome:` label, or terminal provenance/status block in the user summary. When the host or skill requires a terminal status, emit the single exact `Status: <token>` line in the owning result section instead of a bottom metadata block. Expose a path, ID, commit, or recovery detail only when it changes user action or the skill's canonical result schema requires it. Keep phase receipts as internal handoff envelopes: when an active parent requires phase, status, IDs, `Return to`, `Success state`, or `Outstanding transition`, return them only to that parent workflow and never echo them in the terminal user summary.
-
-Persist provenance only in an artifact or ledger the skill already owns. A skill without such an owner must not create one solely to store a receipt, and a read-only skill remains read-only. Never require a shared runtime reference outside this skill.
+Keep progress and the terminal user response separate. Begin directly with `Answer`.
+Do not emit a ceremonial preamble, separator, `Outcome:`, receipt heading,
+duplicated status, or internal handoff fields. This skill is read-only and
+creates no ledger.
 
 ### 🔴 HARD GATE · response language
 
-Before any user-facing progress, question, or summary, resolve the response language from the latest explicit user language instruction; otherwise use the current user message's language. Write every free-form user-facing sentence and every prose result value in that resolved language, and do not switch to English because sources, skill bodies, tools, or code are English. Keep canonical headings, status tokens, IDs, commands, paths, code, and exact quoted or source literals byte-stable; explain them in the resolved language around the preserved token. Before returning, scan all free-form user-facing prose and rewrite any sentence that drifts from the resolved language.
+Use the latest explicit user language, otherwise the current message's language.
+Preserve canonical headings, statuses, paths, commands, code, and exact source
+literals.
 
 ## User decision questions
 
-Normal investigation does not make this skill the decision owner: name the
-decision and stop as `Blocked`. Only when an authorized caller separately
-makes this skill the user-decision owner, ask one self-contained `Question`
-before any `Recommendation`. Show only decision-relevant evidence, two or three
-mutually exclusive options with material tradeoffs, and exactly one label
-ending `(Recommended)` or `(추천)`.
-
-Use native structured input when exposed: Claude Code `AskUserQuestion`, Codex
-`request_user_input`, or Hermes Agent `clarify`. Plain text is allowed only
-when none is exposed. A failed or rejected call is not absence; preserve
-`Pending | Blocked`. This changes presentation, not authority or stop gates.
+Normal investigation does not own decisions: name the decision and stop
+`Blocked`. Only an explicitly authorized decision handoff may ask one
+self-contained `Question` before `Recommendation`, offer two or three mutually
+exclusive options with tradeoffs, and mark one `(Recommended)` or `(추천)`.
+Use Claude Code `AskUserQuestion`, Codex `request_user_input`, or Hermes Agent
+`clarify` when exposed; plain text is allowed only when none exists. A failed or
+rejected tool call preserves `Pending | Blocked`.

--- a/skills/tk-skill-diagnose/SKILL.md
+++ b/skills/tk-skill-diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tk-skill-diagnose
-description: "[user/auto] Reproduce and isolate an observed or measured Agent Skill anomaly in a clean context, including missing or excessive selection, ignored instruction or output contracts, host differences, eval misclassification, unstable or repeated behavior, and abnormal token, time, tool, retry, nested-call, or fan-out use. Do not use for ordinary application bugs, static skill audits, skill creation, typo-only edits, or symptom-free catalog-wide optimization."
+description: "[user/auto] Reproduce and isolate one observed or measured Agent Skill anomaly in a fresh context, then route a verified existing-package objective to tigerkit-evolve. Use for selection, instruction, output, host, eval, stability, or resource incidents. Do not use for ordinary code bugs, static audits, new skill creation, or symptom-free optimization."
 argument-hint: "<skill name/path> <incident prompt, expected, observed, host, metric, or trace>"
 metadata:
   tigerkit:
@@ -11,195 +11,151 @@ metadata:
 
 # Agent Skill Diagnosis
 
-Use this skill only for a specific Agent Skill target plus an observed or
-measured anomaly. Direct selection is allowed. Automatic selection requires
-both target and incident evidence; words such as "skill", "debug", or
-"performance" alone are insufficient.
+Use only for one exact Agent Skill target and one observed or measured anomaly.
+Direct selection is allowed. Automatic selection requires both the target and
+incident evidence; generic words such as "skill", "debug", or "performance" are
+not enough.
 
-Diagnose correctness, stability, compatibility, evaluation validity, and
-resource efficiency. Do not replace ordinary code debugging, `tk-grooming`
-static audits, `tk-learn` semantic writing, `tk-reflect` candidate
-classification, or Darwin-style broad optimization.
+This skill diagnoses. It does not write canonical skills, optimize a catalog,
+or own the final patch. Existing-package changes route to `tigerkit-evolve`;
+new independently useful skills route to `tk-learn`.
 
-## Intake gate
+## Intake
 
-Record the exact target path, host-native location, origin, installed
-version/ref, invocation, prompt, expected behavior or resource anchor, observed
-behavior or metrics, and evidence paths/commands. Mark every unknown value
-`unverified`; never infer it from a name.
+Record:
 
-If there is no incident or measured anomaly, return `NotApplicable` with the
-correct owner boundary. If a fresh executor cannot be used, do not substitute
-self-rereading; return `Unverifiable` or `Blocked`.
+- exact target package/path, installed ref, origin, host, and invocation;
+- incident prompt, expected behavior or metric anchor, and observed result;
+- available transcript/event, file, Git, eval, or resource evidence;
+- known consumer override or host configuration.
 
-An active `tk-reflect` handoff is valid only when its payload supplies:
+Mark missing values `unverified`. No incident or metric anchor is
+`NotApplicable`. Missing fresh execution or inaccessible required evidence is
+`Unverifiable | Blocked`, not permission to infer a cause.
 
-```text
-Incident ID
-Target skill / exact path
-Host and invocation
-Observed prompt
-Expected behavior or resource anchor
-Observed behavior or metrics
-Available evidence paths/commands
-Candidate/baseline refs if present
-Caller: tk-reflect
-```
+A `tk-reflect` handoff is accepted once only when it names the incident, exact
+target, host/invocation, prompt, expected and observed result, and evidence.
+Never call `tk-reflect` or repeat the same target + incident + blocker cycle.
 
-Accept at most one such handoff. Never call `tk-reflect`, and never re-enter an
-equivalent `Incident ID + target + blocker`.
+## Evidence order
+
+Decide in this order:
+
+1. target provenance, description/body consistency, deterministic assertions,
+   repository state, and adapter/host evidence;
+2. the smallest fresh reproduction of the incident;
+3. one nearby control that distinguishes the suspected failure plane;
+4. a run-owned minimum experiment only when needed to prove causality.
+
+Self-report suggests a hypothesis; it does not prove root cause. Repeat a fresh
+run only when the first result is unstable or the boundary remains ambiguous.
+Do not require fixed trial counts, a generic holdout suite, or rubric scoring
+when narrower evidence decides the incident.
+
+Read these references only when applicable:
+
+- [failure planes](references/failure-planes.md)
+- [empirical method](references/empirical-method.md)
+- [upstream issue anonymization](references/upstream-issue-anonymization.md)
 
 ## Workflow
 
-1. `target/provenance`: distinguish TigerKit canonical/adapted source,
-   consumer-local fork/override, and local configuration.
-2. `iteration 0`: compare description trigger/capability promises with body
-   workflow, failures, approval boundary, and output owners. Treat static gaps
-   as reproduction hypotheses only.
-3. `freeze`: define incident/median, nearby control/edge, and an unused holdout;
-   freeze critical requirements before changing any candidate.
-4. `reproduce`: run the current target twice in fresh clean contexts under
-   matched conditions and classify `Reproduced | Not reproduced |
-   Inconclusive`.
-5. `diagnose`: run the separate empirical pass in
-   [empirical-method.md](references/empirical-method.md), keeping deliverable
-   and diagnostic report distinct.
-6. `isolate`: combine self-report with deterministic evidence and map the cause
-   through [failure-planes.md](references/failure-planes.md). Self-report alone
-   never proves root cause.
-7. `experiment`: create a one-theme minimum candidate only in a run-owned
-   isolated checkout/path. State the frozen requirement/assertion served,
-   General Fix Rule, and predicted correctness/resource effect first.
-8. `re-evaluate`: use fresh executors for incident, control, regression cases,
-   and holdout. Require two clean final checks with no new critical regression.
-9. `dispose`: report the exact owner candidate. A semantic skill change becomes
-   a `tk-learn` handoff proposal; an eval/grader/adapter defect names that owner
-   instead.
+1. **Freeze** the exact incident, target ref, must-preserve behavior, affected
+   host, and reliable evidence/metric.
+2. **Reproduce** once in a clean context. Classify
+   `Reproduced | Not reproduced | Inconclusive`.
+3. **Control** the nearest alternative: loader vs body, parent vs child,
+   candidate vs grader, one host vs another, correctness vs resource cost.
+4. **Isolate** the verified failure plane:
+   `selection | loading | instruction | planning | execution | formatting |
+   evaluation | compatibility | efficiency | local override`.
+5. **Experiment when needed** in one run-owned isolated checkout. Change one
+   root-cause theme only and use the experiment to confirm or reject the cause;
+   never treat it as the canonical fix.
+6. **Route** the next owner from verified evidence.
 
-Do not patch a non-reproduced incident from wording intuition. Default to at
-most two candidate themes, two concurrent fresh executors, two trials per
-scenario, and one reflect handoff. Do not nest delegation or sweep the catalog.
+Stop after a conclusive cause or disposition. A second experiment is allowed
+only when the first exposes a new specific cause. Clean only run-owned
+isolation; never rewrite or patch the canonical target.
 
-## Efficiency gate
+## Routes
 
-Require at least one verified stable/no-skill/historical/threshold/candidate
-anchor. Compare the same prompt, host, model/config, tools, repository state,
-and at least two trials. Without an anchor, report `Profile only` and leave
-improvement/regression `Unverifiable`.
+### Existing package: `evolve-ready`
 
-Correctness, safety, routing, mutation, control, or holdout regression always
-outweighs resource savings. Never invent unavailable token, duration, tool,
-retry, nested-call, or fan-out metrics.
-
-## External consumer repositories
-
-When the repository is not TigerKit and the target is `tk-*`, verify TigerKit
-origin/ref, consumer overrides, and—when possible—the incident against
-unmodified upstream source. Consumer-only drift is `local-only`. Before any
-upstream proposal, complete the provenance, reproduction, control/holdout,
-issue-search, and ancestry gates in
-[upstream-issue-anonymization.md](references/upstream-issue-anonymization.md).
-A matching issue is cited and reconciled instead of redrafted. Only
-`upstream-draft-ready` may include an upstream issue title or body; every
-other disposition reports evidence gaps without proposal content.
-Never create, comment on, label, or publish an issue automatically.
-
-## Mutation boundary
-
-Never semantically mutate the canonical source skill. Keep experiments in an
-isolated temporary path, and do not silently change consumer production/code
-files. Do not push, publish, release, rewrite history, or start another skill.
-
-If fresh evidence is missing or a candidate regresses a frozen scenario,
-discard the candidate, preserve the attempted evidence, and clean only
-run-owned isolation. A deterministic regression is `Fail`; unavailable
-required capability is `Blocked`; unverifiable evidence, ownership, or cleanup
-state is `Unverifiable`. Never recover by editing the canonical target.
-
-A validated semantic candidate reports this handoff only:
+Use only when one existing package and one concrete testable objective are
+verified. Emit:
 
 ```text
-Target exact path
-Incident and frozen scenarios
-Verified root cause
-General Fix Rule
-Minimal diff candidate
-Normal/diagnostic/holdout evidence
-Compatibility/resource evidence
-Remaining uncertainty
-Requested tk-learn action
+Target package: skills/<name>/
+Objective: <one observable correction or cost reduction>
+Evidence: <incident, control, code, event, or metric references>
+Must preserve: <behavior, safety, routing, authority, and host boundaries>
+Affected execution: <smallest fresh scenario that decides the objective>
+Metric: <actual measurement, labeled proxy, or unavailable>
+Incident: <stable ID or source reference>
 ```
 
-## Output contract
+This is input to a later explicit `tigerkit-evolve`; do not invoke it.
 
-Assign `SD-01`, `SD-02`, ... in discovery order. Keep one ID for symptoms that
-share a root-cause theme. In chat, emit `## Diagnosis`, `## Action`, optional
-`## Remaining uncertainty`. Diagnosis leads with the
-verified root cause or reproduction verdict; Action names only the next owner
-or validated candidate.
+### Other dispositions
 
-When more than one ID is affected, render `Diagnosis` as a compact
-`ID | Incident | Root cause` table and `Action` as an `ID | Next action` table.
-Use a sentence when only one user-relevant row exists. Rows represent
-root-cause themes, not experiments, hosts, logs, or evidence fragments.
-Summarize two to seven reproduced/root-cause/candidate results as bounded rows
-or bullets. For eight or more, show the top five to seven and cite
-`.tigerkit/skill-diagnosis.md` for the remainder. These are budgets, not quotas.
+- `learn-candidate`: a new independently useful skill is required.
+- `eval-owner`: grader, fixture, harness, or assertion is the verified cause.
+- `host-owner`: loader, metadata, adapter, or host runtime is the verified cause.
+- `local-only`: consumer override/configuration causes the incident.
+- `no-change`: target behavior is correct or the incident is not reproduced.
+- `unverifiable`: evidence cannot decide safely.
 
-When the run uses more than one experiment or host, or has more than five
-evidence rows, write or replace `.tigerkit/skill-diagnosis.md`. Its compact
-rows contain ID, target/provenance, incident, evidence references,
-reproduction, failure plane, root cause, candidate verdict, resource result,
-upstream disposition, and handoff. Never copy raw logs, transcripts, repeated
-rationale, or output metadata. Create the parent lazily, write atomically, and
-warn if scratch is not ignored; never modify `.gitignore`.
+For an external consumer repository, verify upstream origin/ref and current
+upstream behavior before proposing an anonymized issue. Never create, comment,
+label, or publish the issue automatically.
 
-Upstream disposition is exactly `not-applicable | local-only |
-upstream-candidate | upstream-draft-ready | upstream-unverifiable`. Receipt
-provenance belongs in the existing diagnosis ledger when it is written.
-Otherwise expose terminal status, affected IDs, or references only when they
-change the user's next action, without appending metadata. Keep incident state
-separate from terminal status:
+## Result
 
-- `Pass`: the diagnosis workflow and evidence completed; it does not mean the
-  target skill is issue-free.
-- `Fail`: a candidate or diagnosis claim violated a deterministic gate.
-- `Blocked`: a required decision, permission, or environment is unavailable.
-- `Unverifiable`: provenance, reproduction, metrics, or fresh execution could
-  not be verified.
-- `NotApplicable`: no qualifying skill incident exists.
+Lead with `## Diagnosis`, then `## Action`, and add `## Remaining uncertainty`
+only when needed.
+
+For one incident, use short prose. For multiple symptoms sharing one cause, keep
+one stable `SD-##` row per cause in `ID | Incident | Root cause`. Report the
+reproduction verdict, verified failure plane, evidence, route, and exact next
+handoff. Do not copy raw logs, transcripts, screenshots, secrets, or repeated
+run narration.
+
+Use one terminal status:
+
+- `Pass`: diagnosis and routing completed;
+- `Fail`: a deterministic diagnosis/experiment claim violated a gate;
+- `Blocked`: required permission, decision, or environment is unavailable;
+- `Unverifiable`: provenance, reproduction, cause, or metric cannot be verified;
+- `NotApplicable`: no qualifying Agent Skill incident exists.
 
 ### 🔴 HARD GATE · terminal user summary
 
-Treat progress commentary, internal handoff envelopes, and the terminal user response as distinct surfaces. Begin every terminal user-facing response directly with the skill's canonical result heading or, when its result schema owns no heading, its canonical result sentence. Do not emit a standalone separator, ceremonial preamble, or progress recap before that opening. Do not emit a terminal user-summary opening between a successful phase receipt and the next active-drive phase invocation.
-
-Do not render a receipt heading, `Outcome:` label, or terminal provenance/status block in the user summary. When the host or skill requires a terminal status, emit the single exact `Status: <token>` line in the owning result section instead of a bottom metadata block. Expose a path, ID, commit, or recovery detail only when it changes user action or the skill's canonical result schema requires it. Keep phase receipts as internal handoff envelopes: when an active parent requires phase, status, IDs, `Return to`, `Success state`, or `Outstanding transition`, return them only to that parent workflow and never echo them in the terminal user summary.
-
-Persist provenance only in an artifact or ledger the skill already owns. A skill without such an owner must not create one solely to store a receipt, and a read-only skill remains read-only. Never require a shared runtime reference outside this skill.
+Keep progress and the terminal user response separate. Begin directly with `## Diagnosis`.
+Do not emit a ceremonial preamble, `Outcome:`, receipt heading, duplicated
+status, or raw internal handoff. Expose only evidence and paths that change the
+next action.
 
 ### 🔴 HARD GATE · response language
 
-Before any user-facing progress, question, or summary, resolve the response language from the latest explicit user language instruction; otherwise use the current user message's language. Write every free-form user-facing sentence and every prose result value in that resolved language, and do not switch to English because sources, skill bodies, tools, or code are English. Keep canonical headings, status tokens, IDs, commands, paths, code, and exact quoted or source literals byte-stable; explain them in the resolved language around the preserved token. Before returning, scan all free-form user-facing prose and rewrite any sentence that drifts from the resolved language.
+Use the latest explicit user language, otherwise the current message's language.
+Preserve canonical headings, statuses, IDs, commands, paths, schemas, code, and
+quoted literals exactly.
 
 ## User decision questions
 
-When a user-owned decision blocks progress, ask one self-contained `Question`
-before any `Recommendation`. Show only decision-relevant evidence, two or three
-mutually exclusive options with material tradeoffs, and exactly one label
-ending `(Recommended)` or `(추천)`.
+Ask only when a material user-owned decision blocks diagnosis. Put one
+self-contained `Question` before `Recommendation`, offer two or three mutually
+exclusive options with tradeoffs, and mark exactly one `(Recommended)` or
+`(추천)`. Use Claude Code `AskUserQuestion`, Codex `request_user_input`, or
+Hermes Agent `clarify` when exposed; plain text is allowed only when none exists.
+A failed or rejected tool call preserves `Pending | Blocked`.
 
-Use native structured input when exposed: Claude Code `AskUserQuestion`, Codex
-`request_user_input`, or Hermes Agent `clarify`. Plain text is allowed only
-when none is exposed. A failed or rejected call is not absence; preserve
-`Pending | Blocked`. This changes presentation, not authority or stop gates.
+## Pitfalls
 
-## DO NOT / ANTI-PATTERNS
-
-- Do not assume every incident is a SKILL.md wording defect.
-- Do not leak expected outputs, assertion answers, secrets, raw private logs,
-  screenshots, or identifiers into diagnostic prompts or drafts.
-- Do not trade correctness for lower resource use.
-- Do not reuse a learned executor, repeat an equivalent blocker, or replace a
-  fresh executor with self-review.
-- Do not mutate canonical skills or automatically invoke `tk-learn` or
-  `tk-reflect`.
+- Do not assume the skill body is the cause.
+- Do not patch a non-reproduced incident from wording intuition.
+- Do not trade correctness or safety for lower resource use.
+- Do not use fixed repeated runs or judge majorities to manufacture confidence.
+- Do not leak expected answers, secrets, or private evidence into prompts.
+- Do not mutate canonical skills or invoke downstream skills automatically.

--- a/skills/tk-skill-diagnose/SKILL.md
+++ b/skills/tk-skill-diagnose/SKILL.md
@@ -18,9 +18,10 @@ not enough.
 
 This skill diagnoses. It does not write canonical skills, optimize a catalog,
 or own the final patch. Existing-package changes route to `tigerkit-evolve`;
-new independently useful skills route to `tk-learn`.
+new independently useful skills route to `tk-learn`. Never semantically mutate
+the canonical source skill.
 
-## Intake
+## Intake gate
 
 Record:
 
@@ -47,16 +48,24 @@ Decide in this order:
 3. one nearby control that distinguishes the suspected failure plane;
 4. a run-owned minimum experiment only when needed to prove causality.
 
-Self-report suggests a hypothesis; it does not prove root cause. Repeat a fresh
-run only when the first result is unstable or the boundary remains ambiguous.
-Do not require fixed trial counts, a generic holdout suite, or rubric scoring
-when narrower evidence decides the incident.
+Reproduction is `Reproduced | Not reproduced | Inconclusive`. Self-report
+suggests a hypothesis; it does not prove root cause. Repeat a fresh run only
+when the first result is unstable or the boundary remains ambiguous. Do not
+require fixed trial counts, a generic holdout suite, or rubric scoring when
+narrower evidence decides the incident.
 
 Read these references only when applicable:
 
 - [failure planes](references/failure-planes.md)
 - [empirical method](references/empirical-method.md)
 - [upstream issue anonymization](references/upstream-issue-anonymization.md)
+
+## Efficiency gate
+
+A resource claim needs a matched baseline, historical run, repository threshold,
+or explicit budget. Otherwise report the observed value as profile-only and the
+direction as `Unverifiable`. Never offset correctness or safety regression with
+lower tokens, time, calls, retries, or fan-out.
 
 ## Workflow
 
@@ -107,8 +116,9 @@ This is input to a later explicit `tigerkit-evolve`; do not invoke it.
 - `unverifiable`: evidence cannot decide safely.
 
 For an external consumer repository, verify upstream origin/ref and current
-upstream behavior before proposing an anonymized issue. Never create, comment,
-label, or publish the issue automatically.
+upstream behavior before proposing an anonymized issue. Only a duplicate-checked,
+redacted proposal with verified provenance is `upstream-draft-ready`; never
+create, comment, label, or publish it automatically.
 
 ## Result
 
@@ -155,7 +165,7 @@ A failed or rejected tool call preserves `Pending | Blocked`.
 
 - Do not assume the skill body is the cause.
 - Do not patch a non-reproduced incident from wording intuition.
-- Do not trade correctness or safety for lower resource use.
+- Do not trade correctness, safety, or holdout behavior for lower resource use.
 - Do not use fixed repeated runs or judge majorities to manufacture confidence.
 - Do not leak expected answers, secrets, or private evidence into prompts.
 - Do not mutate canonical skills or invoke downstream skills automatically.

--- a/skills/tk-skill-diagnose/references/empirical-method.md
+++ b/skills/tk-skill-diagnose/references/empirical-method.md
@@ -1,47 +1,41 @@
 # Empirical diagnostic method
 
-Use this reference after intake passes. The method adapts mizchi's
-`empirical-prompt-tuning` for incident diagnosis rather than broad prompt
-optimization.
+Read this reference only after intake identifies one exact target and incident.
+It adapts empirical prompt tuning for causal diagnosis, not broad optimization.
 
-## Static iteration 0
+## 1. Static consistency
 
-Before dispatch:
+Before fresh execution, compare the frontmatter description with the body:
 
-1. List the positive and negative trigger promises in the description.
-2. List each capability promise.
-3. Locate its body owner in workflow, failure, approval, mutation, or output
-   contracts.
-4. Record description-only promises, body-only behavior, and contradictory
-   owners as hypotheses.
+- positive and negative triggers;
+- capability and output promises;
+- approval, mutation, failure, and recovery owners.
 
-Static consistency can narrow reproduction but cannot prove cause.
+Description-only promises, body-only behavior, and contradictory owners are
+hypotheses. Static consistency never proves runtime cause.
 
-## Freeze scenarios and requirements
+## 2. Freeze the smallest deciding set
 
-Use this bounded set:
+Freeze before experimentation:
 
 ```text
-A. incident/median: the observed prompt
-B. nearby control/edge: adjacent behavior that should remain valid
-C. holdout: an existing case not used to choose the candidate
+Incident: the observed prompt and expected/observed result
+Control: the nearest adjacent behavior that distinguishes the suspected cause
+Must preserve: critical behavior, safety, routing, authority, and host boundary
+Metric: actual anchor, labeled proxy, or unavailable
 ```
 
-Prefer existing trigger and behavior evals in TigerKit. In an external
-repository, normalize the actual incident without persisting private data.
-Freeze three to seven requirements per scenario, including at least one
-`[critical]` requirement. Do not change requirements or critical tags after
-seeing a candidate.
+Add another scenario only when the first incident/control pair cannot separate
+the failure planes. A generic holdout is optional, not a default ceremony.
 
-## Fresh execution
+## 3. Fresh execution
 
-Run the target twice in clean, matched contexts. Use fresh executors for every
-candidate re-evaluation; an executor that saw the previous diagnosis is not
-fresh. If fresh dispatch is unavailable, stop empirical claims as
-`Unverifiable`.
+Run the incident once in a clean matched context. Repeat only when the result is
+unstable, close to a metric threshold, or ambiguous against the control. An
+executor that saw the diagnosis or candidate is not fresh.
 
-The normal deliverable remains primary. A separate diagnostic suffix asks only
-for:
+Keep the normal deliverable primary. When the adapter supports a diagnostic
+suffix, collect only:
 
 ```json
 {
@@ -54,7 +48,7 @@ for:
   "unclear_points": [
     {
       "issue": "observed event",
-      "cause": "instruction-level cause",
+      "cause": "candidate cause",
       "general_fix_rule": "class-level prevention rule"
     }
   ],
@@ -63,60 +57,41 @@ for:
 }
 ```
 
-Empty issue/fill-in arrays are valid. Do not ask the executor to restate an
-expected output, judge criterion, mechanical expectation, or baseline/candidate
-verdict. Malformed diagnostics are an evaluation-plane record, not proof that
-the normal deliverable failed.
+Do not reveal expected answers, judge criteria, or baseline/candidate verdicts
+to the executor. Malformed diagnostics are evaluation-plane evidence; they do
+not automatically invalidate an otherwise verified deliverable.
 
-## Two-sided evidence
+## 4. Two-sided evidence
 
-Capture:
+Combine:
 
-- normal assertions and deterministic Git/path/runtime evidence;
-- phase-local trace;
-- `Issue / Cause / General Fix Rule`;
-- discretionary fill-ins and retries;
-- available token, duration, tool, nested-call, and fan-out metrics.
+- deterministic assertions and Git/path/runtime evidence;
+- selection/loading and host/adapter events;
+- phase-local trace and discretionary fill-ins;
+- actual token, duration, tool, nested-call, or retry metrics when available.
 
-Qualitative ambiguity is primary; resource metrics are supporting evidence.
-Connect each causal claim to at least one instruction, runtime, routing, or eval
-artifact. Do not accept self-report alone.
+Self-report is one observation, never sufficient cause. Every causal claim
+needs an instruction, routing, runtime, repository, or eval anchor.
 
-## Minimum candidate
+## 5. Minimum experiment
 
-Before creating a temporary candidate, state:
+Use a run-owned isolated checkout only when incident/control evidence cannot
+prove the cause directly. State the suspected cause and expected distinguishing
+result first. Change one root-cause theme and run the smallest affected scenario.
 
-```text
-Frozen requirement/assertion served
-General Fix Rule applied
-Expected correctness effect
-Expected resource effect
-```
+The experiment confirms or rejects causality; it is not the canonical patch.
+A second experiment requires a new specific cause from the first result. Do not
+stack wording changes after the same failure repeats.
 
-Change one root-cause theme per candidate. Related micro-edits may remain one
-theme; unrelated fixes wait. If the same failure class persists after two
-themes, report a structural problem rather than stacking patches.
+## 6. Disposition
 
-## Convergence and holdout
+- verified existing-package objective → compact `evolve-ready` handoff;
+- new independently useful skill → `learn-candidate`;
+- grader/harness/fixture defect → `eval-owner`;
+- loader/adapter/host defect → `host-owner`;
+- consumer override/configuration → `local-only`;
+- not reproduced or target correct → `no-change`;
+- missing decisive evidence → `unverifiable`.
 
-A final candidate needs two consecutive fresh checks with:
-
-- no new unclear point;
-- no repeated `stuck | skipped`;
-- no critical/control regression;
-- no retry regression;
-- matched resource improvement when efficiency is claimed.
-
-Run one unused holdout last. Any correctness, safety, routing, mutation, or
-holdout regression rejects the candidate regardless of token/time savings.
-
-Maintain a run-local failure ledger keyed by normalized General Fix Rule.
-Repeated patterns explain convergence or structural divergence; the ledger is
-never global TigerKit state.
-
-## Cost boundary
-
-Default to one target, one incident, one nearby control, one holdout, two trials
-per scenario, two concurrent fresh executors, and two candidate themes. Stop on
-repeated equivalent blockers, rate limits, or executor failure rather than
-retrying indefinitely.
+Write a temporary diagnostic artifact only when actual telemetry or more than
+five evidence rows require it. Never create a durable optimization ledger.


### PR DESCRIPTION
## Summary

- Add a repository-owned local release gate without GitHub Actions.
- Keep deterministic contract, validator, unit, packaging, diff, candidate-SHA, and tag-safety failures release-blocking.
- Try the live critical matrix in order: Codex → Claude Code → Hermes Agent.
- Stop after the first host that passes every selected liveness and routing case twice.
- Record `quality.status: Advisory` when no adapter is available or no host passes; keep that visible without blocking an otherwise valid release.
- Refactor `tk-skill-diagnose` into adaptive incident diagnosis that routes verified existing-package objectives to `tigerkit-evolve`.
- Compress `tk-ask-repo` while preserving read-only source-location and impact-sweep behavior.

## Gate contract

- Top-level `status: Fail` / `release_blocked: true` only for deterministic release failures.
- Top-level `status: Pass` permits release.
- `quality.status: Pass` names the first successful host.
- `quality.status: Advisory` records unavailable/failed/not-run host evidence and still permits release.
- `--adapter-command` is optional.
- Host order is closed as `codex`, `claude-code`, `hermes-agent`.
- No GitHub Actions workflow is added.

## Validation surface

- `evals/release-critical.json`
- `scripts/run_release_gate.py`
- `scripts/test_run_release_gate.py`
- Existing repository validators and package checks remain part of the blocking static gate.

## Issues

Refs #198
Refs #205