### PR TITLE
chore(release): v21.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 21.0.8 — Eval SSOT and Empirical Quality
+
+- Made skill-local trigger and behavior JSON the single source of truth, removed generated Darwin prompt projections and root fixture mirrors, and replaced hardcoded catalog snapshots with auto-discovery.
+- Added a built-in project-local Codex → Claude Code → Hermes Agent quality adapter that preserves authentication without mutating user skill folders; unavailable live hosts remain visible `Advisory` evidence.
+- Added exact-candidate `tk-drive` versus explicit-composition A/B experiments and an evidence-derived catalog audit; retained all 15 skills because no measured removal evidence was available.
+- Added local release-critical and catalog gates around the new schema while keeping GitHub Actions absent.
+
 ## 21.0.7 — Zero-crust Contracts
 
 - Replaced validator magic-phrase checks with structural checks for user decisions, terminal output, response language, and learning-loop ownership.
@@ -377,7 +384,7 @@
 
 - Added explicit STOP checkpoints before remote changes, Promote integration, release mutations, and post-release main cleanup.
 - Hardened the maintainer release fixtures and validator contract for promotion, resume, dry-run, and post-release branch reconciliation.
-- Preserved the 13 canonical skill distribution and runtime-neutral release workflow.
+- Preserved the 13-skill distribution and runtime-neutral release workflow.
 
 ## 19.0.11 — Canonical Skill Workflow Optimization
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="assets/tigerkit-cover.png" width="960" alt="TigerKit Agent Skills 표지">
 </p>
 
-TigerKit 21.0.7은 Claude Code, Codex, Hermes Agent용 엔지니어링 Agent Skills
+TigerKit 21.0.8은 Claude Code, Codex, Hermes Agent용 엔지니어링 Agent Skills
 모음입니다. 중앙 workflow runtime이나 plugin 없이 15개 self-contained skill을
-`npx skills`로 배포합니다. 최신 immutable snapshot은 `v21.0.7`이며 `main`에는
+`npx skills`로 배포합니다. 최신 immutable snapshot은 `v21.0.8`이며 `main`에는
 다음 릴리스 변경이 포함될 수 있습니다.
 
 ## 설치
@@ -23,7 +23,7 @@ npx skills add MTGVim/tiger-kit \
 고정 snapshot:
 
 ```bash
-npx skills add "MTGVim/tiger-kit#v21.0.7" \
+npx skills add "MTGVim/tiger-kit#v21.0.8" \
   --global \
   --agent claude-code \
   --agent codex \


### PR DESCRIPTION
## Release range

- `v21.0.7..e3c45bea728c791be1c59aedcb16cc6179ab4c88`

## Summary

- Make skill-local trigger/behavior JSON the eval SSOT and remove generated Darwin/root mirror surfaces.
- Add the built-in ordered host quality adapter, exact-candidate drive A/B experiment, and evidence-derived catalog audit.
- Keep all 15 skills because no measured removal evidence was available.
- Publish current README and changelog metadata for `v21.0.8`.

## Validation

- Release diff is metadata-only relative to exact `main`: README + CHANGELOG.
- Feature diff and safety boundaries were reviewed on PR #219.
- Live host quality: `Advisory` in this session because no authenticated local host execution was available.
- GitHub Actions: not used.

## Issues

Issues: none