### PR TITLE
chore(release): v2026.08.01-2-fd50d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2026.08.01-2 — Release
+
+- feat: split PR lifecycle into canonical skills
+
 ## 2026.08.01-1 — Release
 
 - fix: validate date release snapshots

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="assets/tigerkit-cover.png" width="960" alt="TigerKit Agent Skills 표지">
 </p>
 
-TigerKit 2026.08.01-1-989e5은 Claude Code, Codex, Hermes Agent용 엔지니어링 Agent Skills
+TigerKit 2026.08.01-2-fd50d은 Claude Code, Codex, Hermes Agent용 엔지니어링 Agent Skills
 모음입니다. 중앙 workflow runtime이나 plugin 없이 self-contained skill을
-`npx skills`로 배포합니다. 최신 immutable snapshot은 `v2026.08.01-1-989e5`이며, 이
+`npx skills`로 배포합니다. 최신 immutable snapshot은 `v2026.08.01-2-fd50d`이며, 이
 snapshot은 14개 skill을 포함합니다. 현재 `main`에는 다음 릴리스 후보가 포함될 수 있습니다.
 
 ## 설치
@@ -23,7 +23,7 @@ npx skills add MTGVim/tiger-kit \
 고정 snapshot:
 
 ```bash
-npx skills add "MTGVim/tiger-kit#v2026.08.01-1-989e5" \
+npx skills add "MTGVim/tiger-kit#v2026.08.01-2-fd50d" \
   --global \
   --agent claude-code \
   --agent codex \
@@ -161,7 +161,7 @@ Release gate:
 
 ```bash
 python3 scripts/run_release_gate.py \
-  --baseline v2026.08.01-1-989e5 \
+  --baseline v2026.08.01-2-fd50d \
   --candidate HEAD \
   --output /tmp/tigerkit-release-gate
 ```


### PR DESCRIPTION
## Release range

- `v2026.08.01-1-989e5..fd50dd031280548776fa4db7ec18839b25732ea2`

## Validation

- Static gate: Pass
- Live quality: Advisory

## Issues

Issues: none